### PR TITLE
feat(roadflare): Kind 3189 driver ping receiver (Issue #4)

### DIFF
--- a/common/src/main/java/com/ridestr/common/nostr/events/RideshareEventKinds.kt
+++ b/common/src/main/java/com/ridestr/common/nostr/events/RideshareEventKinds.kt
@@ -219,7 +219,7 @@ object RideshareEventKinds {
      * Auth proof: HMAC-SHA256(key = driver's RoadFlare privateKey bytes,
      *   msg = driverPubkey + riderPubkey + str(floor(epochSeconds / 300)))
      * Driver validates against currentWindow ± 1 (5-minute buckets, clock-skew tolerance).
-     * Uses "expiration" NIP-40 tag (epoch + 1800, 30-minute TTL).
+     * Uses "expiration" NIP-40 tag (epoch + RideshareExpiration.ROADFLARE_DRIVER_PING_MINUTES * 60).
      *
      * Protocol spec: roadflare-ios plan docs/superpowers/plans/2026-04-14-issue-4-driver-ping.md §1
      */
@@ -386,9 +386,10 @@ object RideshareExpiration {
     const val RIDE_CANCELLATION_HOURS = 24
 
     // RoadFlare events
-    const val ROADFLARE_LOCATION_MINUTES = 5     // Real-time location, short TTL
-    const val ROADFLARE_REQUEST_MINUTES = 15     // Same as ride offer
-    const val ROADFLARE_SHAREABLE_LIST_DAYS = 30 // Shareable driver lists
+    const val ROADFLARE_LOCATION_MINUTES = 5       // Real-time location, short TTL
+    const val ROADFLARE_REQUEST_MINUTES = 15       // Same as ride offer
+    const val ROADFLARE_DRIVER_PING_MINUTES = 30   // Driver ping nudge (Kind 3189)
+    const val ROADFLARE_SHAREABLE_LIST_DAYS = 30   // Shareable driver lists
 
     // Helper function for days
     fun daysFromNow(days: Int): Long =

--- a/common/src/main/java/com/ridestr/common/nostr/events/RideshareEventKinds.kt
+++ b/common/src/main/java/com/ridestr/common/nostr/events/RideshareEventKinds.kt
@@ -212,6 +212,20 @@ object RideshareEventKinds {
     const val ROADFLARE_KEY_ACK = 3188
 
     /**
+     * Kind 3189: RoadFlare Driver Ping Request (Regular)
+     * Sent by a rider to nudge an offline trusted driver to come online.
+     * Content is NIP-44 encrypted to the driver's Nostr identity pubkey.
+     *
+     * Auth proof: HMAC-SHA256(key = driver's RoadFlare privateKey bytes,
+     *   msg = driverPubkey + riderPubkey + str(floor(epochSeconds / 300)))
+     * Driver validates against currentWindow ± 1 (5-minute buckets, clock-skew tolerance).
+     * Uses "expiration" NIP-40 tag (epoch + 1800, 30-minute TTL).
+     *
+     * Protocol spec: roadflare-ios plan docs/superpowers/plans/2026-04-14-issue-4-driver-ping.md §1
+     */
+    const val ROADFLARE_DRIVER_PING = 3189
+
+    /**
      * Kind 30175: Vehicle Backup Event (Parameterized Replaceable)
      * @deprecated Use PROFILE_BACKUP (30177) instead. Vehicles are now part of unified profile backup.
      */
@@ -340,6 +354,7 @@ object RideshareTags {
     const val GEOHASH = "g"
     const val RIDESHARE_TAG = "rideshare"
     const val EXPIRATION = "expiration"  // NIP-40
+    const val AUTH = "auth"        // HMAC auth proof (Kind 3189)
 }
 
 /**

--- a/common/src/main/java/com/ridestr/common/nostr/events/RoadflareDriverPingEvent.kt
+++ b/common/src/main/java/com/ridestr/common/nostr/events/RoadflareDriverPingEvent.kt
@@ -109,11 +109,28 @@ object RoadflareDriverPingEvent {
         return try {
             val decrypted = signer.nip44Decrypt(event.content, event.pubKey)
             val json = JSONObject(decrypted)
+
+            // Require action == "ping"; reject anything else as malformed.
+            // Silent drop — same failure path as HMAC failure.
+            val action = json.optString("action", "")
+            if (action != "ping") {
+                Log.d(TAG, "Invalid action in driver ping payload: '$action'")
+                return null
+            }
+
+            // "message" field is intentionally not parsed. The notification body is
+            // constructed locally in the service from riderName only — the sender's
+            // message field is untrusted and must never reach the notification copy.
+            // riderName is sanitised here (truncate + strip control chars) to prevent
+            // injection even through the weaker sender-controlled display name.
+            val safeRiderName = json.optString("riderName", "")
+                .take(64)
+                .filter { it >= ' ' }
+
             RoadflareDriverPingData(
                 riderPubKey = event.pubKey,
-                message     = json.optString("message",   ""),
-                riderName   = json.optString("riderName", ""),
-                timestamp   = json.optLong("timestamp",   nowEpoch)
+                riderName   = safeRiderName,
+                timestamp   = json.optLong("timestamp", nowEpoch)
             )
         } catch (e: Exception) {
             Log.e(TAG, "Failed to decrypt driver ping from ${event.pubKey.take(8)}", e)
@@ -141,10 +158,16 @@ object RoadflareDriverPingEvent {
         joinToString("") { "%02x".format(it.toInt() and 0xFF) }
 }
 
-/** Parsed content from a validated Kind 3189 driver ping event. */
+/**
+ * Parsed content from a validated Kind 3189 driver ping event.
+ *
+ * Security note: the raw payload's `message` field is intentionally absent here.
+ * Any receiver that needs to display a notification MUST build the body locally
+ * from [riderName] — never from a sender-supplied string. [riderName] is already
+ * sanitised (64-char truncation, control-char strip) at parse time.
+ */
 data class RoadflareDriverPingData(
     val riderPubKey: String,  // event.pubKey — Nostr sender
-    val message: String,       // pre-formatted notification body from "message" field
-    val riderName: String,     // rider's display name from "riderName" field
-    val timestamp: Long        // unix epoch from "timestamp" field
+    val riderName: String,    // rider's display name (sanitised); use to build notification body locally
+    val timestamp: Long       // unix epoch from "timestamp" field
 )

--- a/common/src/main/java/com/ridestr/common/nostr/events/RoadflareDriverPingEvent.kt
+++ b/common/src/main/java/com/ridestr/common/nostr/events/RoadflareDriverPingEvent.kt
@@ -1,0 +1,150 @@
+package com.ridestr.common.nostr.events
+
+import android.util.Log
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
+import org.json.JSONObject
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Kind 3189: RoadFlare Driver Ping Request (Regular)
+ *
+ * Sent by a rider to nudge an offline trusted driver to come online.
+ * Content is NIP-44 encrypted to the driver's Nostr identity pubkey.
+ *
+ * Auth proof: HMAC-SHA256(key = driver's RoadFlare privateKey bytes,
+ *   msg = driverPubkey + riderPubkey + str(floor(epochSeconds / 300)))
+ * Validated against currentWindow ± 1 (5-minute buckets, clock-skew tolerance).
+ *
+ * Protocol spec: roadflare-ios plan docs/superpowers/plans/2026-04-14-issue-4-driver-ping.md §1
+ */
+object RoadflareDriverPingEvent {
+    private const val TAG = "DriverPingEvent"
+    const val T_TAG = "roadflare-ping"
+    private const val HMAC_WINDOW_SECONDS = 300L  // 5-minute bucket
+    private const val HMAC_ALGORITHM = "HmacSHA256"
+
+    /**
+     * Validate the HMAC auth tag on a Kind 3189 event.
+     *
+     * Checks three consecutive 5-minute windows (currentWindow - 1, currentWindow,
+     * currentWindow + 1) to tolerate clock skew and window boundary crossings.
+     *
+     * @param event               The raw Nostr event (event.pubKey = rider's Nostr pubkey)
+     * @param driverPubKey        Driver's Nostr identity pubkey (hex)
+     * @param roadflarePrivKeyHex Driver's RoadFlare private key (64-char lowercase hex = 32 bytes)
+     * @param nowEpoch            Current unix timestamp in seconds (injectable for testing)
+     * @return true if any of the three windows produces a matching HMAC
+     */
+    fun isAuthValid(
+        event: Event,
+        driverPubKey: String,
+        roadflarePrivKeyHex: String,
+        nowEpoch: Long = System.currentTimeMillis() / 1000
+    ): Boolean {
+        val authTag = event.tags.find { it.getOrNull(0) == RideshareTags.AUTH }
+            ?.getOrNull(1)?.lowercase() ?: return false
+        if (authTag.length != 64) return false  // SHA256 hex is exactly 64 chars
+
+        return try {
+            val keyBytes = roadflarePrivKeyHex.hexToBytes()
+            val riderPubKey = event.pubKey
+            val currentWindow = nowEpoch / HMAC_WINDOW_SECONDS
+
+            listOf(currentWindow - 1L, currentWindow, currentWindow + 1L).any { window ->
+                val msg = driverPubKey + riderPubKey + window.toString()
+                computeHmac(keyBytes, msg).toHexString() == authTag
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "HMAC validation error: ${e.message}")
+            false
+        }
+    }
+
+    /**
+     * Full validation and decryption pipeline for a Kind 3189 event.
+     *
+     * Validation order (each failure returns null — silent from the user's perspective;
+     * DEBUG-level log lines remain for local troubleshooting):
+     * 1. Wrong kind
+     * 2. NIP-40 expiry exceeded
+     * 3. HMAC auth mismatch
+     * 4. NIP-44 decrypt or JSON parse failure
+     *
+     * @param signer              Driver's Nostr signer (for NIP-44 decryption)
+     * @param event               The raw Kind 3189 event
+     * @param driverPubKey        Driver's Nostr identity pubkey (hex)
+     * @param roadflarePrivKeyHex Driver's RoadFlare private key (64-char lowercase hex)
+     * @param nowEpoch            Current unix timestamp in seconds (injectable for testing)
+     * @return Parsed data on success, null on any validation failure
+     */
+    suspend fun parseAndDecrypt(
+        signer: NostrSigner,
+        event: Event,
+        driverPubKey: String,
+        roadflarePrivKeyHex: String,
+        nowEpoch: Long = System.currentTimeMillis() / 1000
+    ): RoadflareDriverPingData? {
+        if (event.kind != RideshareEventKinds.ROADFLARE_DRIVER_PING) {
+            Log.w(TAG, "Wrong event kind: ${event.kind}")
+            return null
+        }
+
+        // NIP-40: relays should enforce expiry, but driver app must not trust relays.
+        // Missing expiration tag is also rejected — spec §1.6 requires a 30-min TTL on every event.
+        val expiration = event.tags.find { it.getOrNull(0) == RideshareTags.EXPIRATION }
+            ?.getOrNull(1)?.toLongOrNull()
+        if (expiration == null || expiration < nowEpoch) {
+            Log.d(TAG, "Dropping driver ping — expiry absent or exceeded (exp=$expiration, now=$nowEpoch)")
+            return null
+        }
+
+        // HMAC auth (silent drop on failure — no error response to sender)
+        if (!isAuthValid(event, driverPubKey, roadflarePrivKeyHex, nowEpoch)) {
+            Log.d(TAG, "HMAC auth failed for ping from ${event.pubKey.take(8)}")
+            return null
+        }
+
+        return try {
+            val decrypted = signer.nip44Decrypt(event.content, event.pubKey)
+            val json = JSONObject(decrypted)
+            RoadflareDriverPingData(
+                riderPubKey = event.pubKey,
+                message     = json.optString("message",   ""),
+                riderName   = json.optString("riderName", ""),
+                timestamp   = json.optLong("timestamp",   nowEpoch)
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to decrypt driver ping from ${event.pubKey.take(8)}", e)
+            null
+        }
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    private fun computeHmac(key: ByteArray, message: String): ByteArray {
+        val mac = Mac.getInstance(HMAC_ALGORITHM)
+        mac.init(SecretKeySpec(key, HMAC_ALGORITHM))
+        return mac.doFinal(message.toByteArray(Charsets.UTF_8))
+    }
+
+    /** Decode a lowercase hex string to bytes. Throws if length is odd. */
+    private fun String.hexToBytes(): ByteArray {
+        check(length % 2 == 0) { "Hex string must have even length, got $length" }
+        return ByteArray(length / 2) { i ->
+            Integer.parseInt(substring(i * 2, i * 2 + 2), 16).toByte()
+        }
+    }
+
+    private fun ByteArray.toHexString(): String =
+        joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+}
+
+/** Parsed content from a validated Kind 3189 driver ping event. */
+data class RoadflareDriverPingData(
+    val riderPubKey: String,  // event.pubKey — Nostr sender
+    val message: String,       // pre-formatted notification body from "message" field
+    val riderName: String,     // rider's display name from "riderName" field
+    val timestamp: Long        // unix epoch from "timestamp" field
+)

--- a/common/src/main/java/com/ridestr/common/notification/NotificationHelper.kt
+++ b/common/src/main/java/com/ridestr/common/notification/NotificationHelper.kt
@@ -24,6 +24,7 @@ object NotificationHelper {
     const val CHANNEL_RIDE_UPDATE = "ride_update"
     const val CHANNEL_RIDE_CANCELLED = "ride_cancelled"
     const val CHANNEL_FOLLOW_REQUEST = "follow_request"
+    const val CHANNEL_DRIVER_PING    = "driver_ping"
 
     // Notification IDs
     const val NOTIFICATION_ID_ONLINE_STATUS = 1001
@@ -94,8 +95,19 @@ object NotificationHelper {
                 description = "Notifications when a rider adds you to their driver network"
             }
 
+            // Channel 6: Driver pings — friendly nudge from followers to come online
+            val pingChannel = NotificationChannel(
+                CHANNEL_DRIVER_PING,
+                "Driver Pings",
+                NotificationManager.IMPORTANCE_DEFAULT
+            ).apply {
+                description = "Notifications when a follower asks you to come online"
+                setSound(null, null)       // SoundManager handles audio
+                enableVibration(false)     // SoundManager handles vibration
+            }
+
             notificationManager.createNotificationChannels(
-                listOf(onlineChannel, requestChannel, updateChannel, cancelledChannel, followChannel)
+                listOf(onlineChannel, requestChannel, updateChannel, cancelledChannel, followChannel, pingChannel)
             )
         }
     }

--- a/common/src/test/java/com/ridestr/common/nostr/events/RoadflareDriverPingEventTest.kt
+++ b/common/src/test/java/com/ridestr/common/nostr/events/RoadflareDriverPingEventTest.kt
@@ -1,0 +1,219 @@
+package com.ridestr.common.nostr.events
+
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.json.JSONObject
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class RoadflareDriverPingEventTest {
+
+    // Fixed test inputs — chosen so fixedEpoch / 300 = 3333 exactly (no boundary ambiguity)
+    private val driverPubKey        = "d" + "0".repeat(63)   // 64-char hex
+    private val riderPubKey         = "a" + "0".repeat(63)   // 64-char hex
+    private val roadflarePrivKeyHex = "bb".repeat(32)         // 64-char hex = 32 bytes
+    private val fixedEpoch          = 1_000_000L              // window = 3333
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /**
+     * Compute HMAC-SHA256 using the same algorithm as the SUT.
+     * Used to build expected auth-tag values in tests.
+     */
+    private fun computeHmac(privKeyHex: String, driverPub: String, riderPub: String, window: Long): String {
+        val key = ByteArray(privKeyHex.length / 2) { i ->
+            Integer.parseInt(privKeyHex.substring(i * 2, i * 2 + 2), 16).toByte()
+        }
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(key, "HmacSHA256"))
+        val msg = driverPub + riderPub + window.toString()
+        return mac.doFinal(msg.toByteArray(Charsets.UTF_8)).joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+    }
+
+    /** Build a mock Event with configurable kind, pubkey, auth tag, and expiration. */
+    private fun makeEvent(
+        kind: Int = RideshareEventKinds.ROADFLARE_DRIVER_PING,
+        pubKey: String = riderPubKey,
+        authTag: String? = null,
+        expiration: Long? = fixedEpoch + 1800
+    ): Event {
+        val event = mockk<Event>(relaxed = true)
+        every { event.kind } returns kind
+        every { event.pubKey } returns pubKey
+        every { event.content } returns "encrypted_content"
+        val tagList = mutableListOf<Array<String>>()
+        if (authTag != null)   tagList.add(arrayOf("auth",       authTag))
+        if (expiration != null) tagList.add(arrayOf("expiration", expiration.toString()))
+        every { event.tags } returns tagList.toTypedArray()
+        return event
+    }
+
+    /** Convenience: valid auth hex for a given window (defaults to current). */
+    private fun validAuthHex(window: Long = fixedEpoch / 300): String =
+        computeHmac(roadflarePrivKeyHex, driverPubKey, riderPubKey, window)
+
+    // ── isAuthValid ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `isAuthValid returns true for HMAC at current window`() {
+        val event = makeEvent(authTag = validAuthHex())
+        assertTrue(
+            RoadflareDriverPingEvent.isAuthValid(event, driverPubKey, roadflarePrivKeyHex, fixedEpoch)
+        )
+    }
+
+    @Test
+    fun `isAuthValid returns true for HMAC at previous window`() {
+        val event = makeEvent(authTag = validAuthHex(fixedEpoch / 300 - 1))
+        assertTrue(
+            RoadflareDriverPingEvent.isAuthValid(event, driverPubKey, roadflarePrivKeyHex, fixedEpoch)
+        )
+    }
+
+    @Test
+    fun `isAuthValid returns true for HMAC at next window`() {
+        val event = makeEvent(authTag = validAuthHex(fixedEpoch / 300 + 1))
+        assertTrue(
+            RoadflareDriverPingEvent.isAuthValid(event, driverPubKey, roadflarePrivKeyHex, fixedEpoch)
+        )
+    }
+
+    @Test
+    fun `isAuthValid returns false for HMAC two windows back`() {
+        val event = makeEvent(authTag = validAuthHex(fixedEpoch / 300 - 2))
+        assertFalse(
+            RoadflareDriverPingEvent.isAuthValid(event, driverPubKey, roadflarePrivKeyHex, fixedEpoch)
+        )
+    }
+
+    @Test
+    fun `isAuthValid returns false for HMAC two windows ahead`() {
+        val event = makeEvent(authTag = validAuthHex(fixedEpoch / 300 + 2))
+        assertFalse(
+            RoadflareDriverPingEvent.isAuthValid(event, driverPubKey, roadflarePrivKeyHex, fixedEpoch)
+        )
+    }
+
+    @Test
+    fun `isAuthValid returns false for wrong roadflare key`() {
+        val event = makeEvent(authTag = validAuthHex())
+        val wrongKey = "cc".repeat(32)
+        assertFalse(
+            RoadflareDriverPingEvent.isAuthValid(event, driverPubKey, wrongKey, fixedEpoch)
+        )
+    }
+
+    @Test
+    fun `isAuthValid returns false when auth tag is absent`() {
+        val event = makeEvent(authTag = null)
+        assertFalse(
+            RoadflareDriverPingEvent.isAuthValid(event, driverPubKey, roadflarePrivKeyHex, fixedEpoch)
+        )
+    }
+
+    @Test
+    fun `isAuthValid returns false for wrong-length auth tag`() {
+        // 63-char hex trips the authTag.length != 64 guard before HMAC is attempted
+        val event = makeEvent(authTag = validAuthHex().take(63))
+        assertFalse(
+            RoadflareDriverPingEvent.isAuthValid(event, driverPubKey, roadflarePrivKeyHex, fixedEpoch)
+        )
+    }
+
+    // ── parseAndDecrypt ──────────────────────────────────────────────────────
+
+    @Test
+    fun `parseAndDecrypt returns null for wrong kind`() = runBlocking {
+        val signer = mockk<NostrSigner>(relaxed = true)
+        val event = makeEvent(kind = 9999)
+        assertNull(
+            RoadflareDriverPingEvent.parseAndDecrypt(signer, event, driverPubKey, roadflarePrivKeyHex, fixedEpoch)
+        )
+    }
+
+    @Test
+    fun `parseAndDecrypt returns null for expired event`() = runBlocking {
+        val signer = mockk<NostrSigner>(relaxed = true)
+        val event = makeEvent(authTag = validAuthHex(), expiration = fixedEpoch - 1)
+        assertNull(
+            RoadflareDriverPingEvent.parseAndDecrypt(signer, event, driverPubKey, roadflarePrivKeyHex, fixedEpoch)
+        )
+    }
+
+    @Test
+    fun `parseAndDecrypt returns null when expiration tag is absent`() = runBlocking {
+        // Spec §1.6 requires every Kind 3189 event to carry a 30-min NIP-40 expiry tag.
+        // Events without expiration are rejected — a missing tag signals a malformed or
+        // unauthenticated sender rather than a benign omission.
+        val signer = mockk<NostrSigner>(relaxed = true)
+        val event = makeEvent(authTag = validAuthHex(), expiration = null)
+        assertNull(
+            RoadflareDriverPingEvent.parseAndDecrypt(signer, event, driverPubKey, roadflarePrivKeyHex, fixedEpoch)
+        )
+    }
+
+    @Test
+    fun `parseAndDecrypt accepts event expiring in the future`() = runBlocking {
+        // Positive-boundary mirror of the expired test: expiration = fixedEpoch + 1
+        // verifies the strict-inequality check (expiration < nowEpoch) passes an event
+        // that still has 1 second of TTL remaining.
+        val signer = mockk<NostrSigner>(relaxed = true)
+        val decryptedJson = JSONObject().apply {
+            put("action",    "ping")
+            put("riderName", "Bob")
+            put("message",   "Bob is currently hoping you come online!")
+            put("timestamp", fixedEpoch)
+        }.toString()
+        coEvery { signer.nip44Decrypt(any(), any()) } returns decryptedJson
+
+        val event = makeEvent(authTag = validAuthHex(), expiration = fixedEpoch + 1)
+        val result = RoadflareDriverPingEvent.parseAndDecrypt(
+            signer, event, driverPubKey, roadflarePrivKeyHex, fixedEpoch
+        )
+        assertNotNull(result)
+        assertEquals("Bob", result!!.riderName)
+    }
+
+    @Test
+    fun `parseAndDecrypt returns null when HMAC auth fails`() = runBlocking {
+        val signer = mockk<NostrSigner>(relaxed = true)
+        val event = makeEvent(authTag = "00".repeat(32))  // wrong HMAC
+        assertNull(
+            RoadflareDriverPingEvent.parseAndDecrypt(signer, event, driverPubKey, roadflarePrivKeyHex, fixedEpoch)
+        )
+    }
+
+    @Test
+    fun `parseAndDecrypt returns data with message and riderName on success`() = runBlocking {
+        val signer = mockk<NostrSigner>(relaxed = true)
+        val decryptedJson = JSONObject().apply {
+            put("action",    "ping")
+            put("riderName", "Alice")
+            put("message",   "Alice is currently hoping you come online!")
+            put("timestamp", fixedEpoch)
+        }.toString()
+        coEvery { signer.nip44Decrypt(any(), any()) } returns decryptedJson
+
+        val event = makeEvent(authTag = validAuthHex())
+        val result = RoadflareDriverPingEvent.parseAndDecrypt(
+            signer, event, driverPubKey, roadflarePrivKeyHex, fixedEpoch
+        )
+
+        assertNotNull(result)
+        assertEquals("Alice is currently hoping you come online!", result!!.message)
+        assertEquals("Alice",      result.riderName)
+        assertEquals(riderPubKey,  result.riderPubKey)
+        assertEquals(fixedEpoch,   result.timestamp)
+    }
+}

--- a/common/src/test/java/com/ridestr/common/nostr/events/RoadflareDriverPingEventTest.kt
+++ b/common/src/test/java/com/ridestr/common/nostr/events/RoadflareDriverPingEventTest.kt
@@ -195,7 +195,7 @@ class RoadflareDriverPingEventTest {
     }
 
     @Test
-    fun `parseAndDecrypt returns data with message and riderName on success`() = runBlocking {
+    fun `parseAndDecrypt returns riderPubKey riderName and timestamp on success`() = runBlocking {
         val signer = mockk<NostrSigner>(relaxed = true)
         val decryptedJson = JSONObject().apply {
             put("action",    "ping")
@@ -211,9 +211,56 @@ class RoadflareDriverPingEventTest {
         )
 
         assertNotNull(result)
-        assertEquals("Alice is currently hoping you come online!", result!!.message)
-        assertEquals("Alice",      result.riderName)
+        assertEquals("Alice",      result!!.riderName)
         assertEquals(riderPubKey,  result.riderPubKey)
         assertEquals(fixedEpoch,   result.timestamp)
+    }
+
+    @Test
+    fun `parseAndDecrypt returns null when action is not ping`() = runBlocking {
+        val signer = mockk<NostrSigner>(relaxed = true)
+        val decryptedJson = JSONObject().apply {
+            put("action",    "not-a-ping")
+            put("riderName", "Alice")
+            put("timestamp", fixedEpoch)
+        }.toString()
+        coEvery { signer.nip44Decrypt(any(), any()) } returns decryptedJson
+
+        val event = makeEvent(authTag = validAuthHex())
+        assertNull(
+            RoadflareDriverPingEvent.parseAndDecrypt(
+                signer, event, driverPubKey, roadflarePrivKeyHex, fixedEpoch
+            )
+        )
+    }
+
+    @Test
+    fun `parseAndDecrypt ignores sender-controlled message field`() = runBlocking {
+        // Security: any follower with the RoadFlare key could craft a custom client
+        // and set message to arbitrary text. The parsed data must not carry that field;
+        // the notification body must be built locally from riderName only.
+        val signer = mockk<NostrSigner>(relaxed = true)
+        val decryptedJson = JSONObject().apply {
+            put("action",    "ping")
+            put("riderName", "Alice")
+            put("message",   "CLICK HERE: evil.com")  // attacker-controlled
+            put("timestamp", fixedEpoch)
+        }.toString()
+        coEvery { signer.nip44Decrypt(any(), any()) } returns decryptedJson
+
+        val event = makeEvent(authTag = validAuthHex())
+        val result = RoadflareDriverPingEvent.parseAndDecrypt(
+            signer, event, driverPubKey, roadflarePrivKeyHex, fixedEpoch
+        )
+
+        assertNotNull(result)
+        assertEquals("Alice", result!!.riderName)
+
+        // Simulate what the service does: build body from riderName only.
+        val notificationBody = "${result.riderName} is hoping you come online"
+        assertFalse(
+            "Notification body must not contain attacker-supplied message",
+            notificationBody.contains("evil.com")
+        )
     }
 }

--- a/docs/protocol/NOSTR_EVENTS.md
+++ b/docs/protocol/NOSTR_EVENTS.md
@@ -24,7 +24,7 @@ This document defines all Nostr event kinds used in the Ridestr rideshare applic
 | [7375](#kind-7375-wallet-proofs) | Wallet Proofs | Regular | Wallet | Owner | Cashu proofs backup (NIP-60) |
 | [17375](#kind-17375-wallet-metadata) | Wallet Metadata | Replaceable | Wallet | Owner | Wallet settings/mint URL (NIP-60) |
 | [30182](#kind-30182-admin-config) | Admin Config | Param. Replaceable | Admin | Admin | Platform settings (fare rates, mints, versions) |
-| [30011-30014, 3186-3188](#extension-roadflare-personal-driver-network) | RoadFlare | Various | Extension | Various | Personal driver network with encrypted location |
+| [30011-30014, 3186-3189](#extension-roadflare-personal-driver-network) | RoadFlare | Various | Extension | Various | Personal driver network with encrypted location |
 
 ---
 
@@ -46,7 +46,7 @@ Any app implementing these **8 event kinds** can fully participate in core ride 
 **Payment is pluggable.** The `payment_method` field supports any value (`"cashu"`, `"lightning"`, `"fiat_cash"`, `"venmo"`, etc.). Cashu HTLC escrow and cross-mint bridge are Ridestr-specific extensions — non-Cashu apps can ignore `preimage_share`, `bridge_complete`, and `deposit_invoice_share` actions in ride state events and still interoperate on core ride coordination.
 
 **Optional extensions** (not required for interop):
-- **RoadFlare** (Kinds 30011-30014, 3186-3188): Personal driver network with encrypted location sharing and key management.
+- **RoadFlare** (Kinds 30011-30014, 3186-3189): Personal driver network with encrypted location sharing and key management.
 - **Backup** (Kinds 30174, 30177): NIP-44 self-encrypted ride history and profile sync.
 - **Admin** (Kind 30182): Platform-level fare config from a trusted admin pubkey.
 
@@ -1170,6 +1170,55 @@ RoadFlare enables riders to build a personal rideshare network from drivers they
 5. If valid, driver re-sends current key via Kind 3186
 
 _Kind 30013 (Shareable Driver List): Reserved for future use — not yet implemented._
+
+### Kind 3189: RoadFlare Driver Ping Request
+
+**Purpose**: Rider nudges an offline trusted driver to come online. Only sent to drivers in the rider's personal RoadFlare network (i.e., drivers the rider has followed and received a key from).
+
+**Type**: Regular Event (with expiration)
+
+**Author**: Rider
+
+**Tags**:
+```
+["p",          "<driver_pubkey>"]
+["t",          "roadflare-ping"]
+["auth",       "<HMAC-SHA256 hex — see Auth Tag below>"]
+["expiration", "<unix_timestamp>"]  // epoch + 1800 (30 minutes)
+```
+
+**Content** (NIP-44 encrypted to driver's Nostr identity pubkey):
+```json
+{
+  "action":    "ping",
+  "riderName": "<rider's display name>",
+  "message":   "<riderName> is currently hoping you come online!",
+  "timestamp": 1706300000
+}
+```
+
+**Auth Tag**:
+
+Proves the sender holds the driver's RoadFlare private key without exposing it.
+
+```
+key:    driver's RoadFlare private key bytes (32 bytes, from 64-char hex privateKey field)
+msg:    UTF-8 of: driverPubkey + riderPubkey + String(floor(epochSeconds / 300))
+output: lowercase hex-encoded HMAC-SHA256
+```
+
+Driver validates against three consecutive 5-minute windows (`currentWindow - 1`, `currentWindow`, `currentWindow + 1`) to tolerate clock skew and window boundary crossings. Silent drop on mismatch — no error response to sender.
+
+**Expiry**: 30 minutes (`epoch + 1800`). Relay GCs expired events; driver app enforces locally and must not trust relays to do so.
+
+**Receiver Responsibilities** (drivestr `RoadflareListenerService`):
+1. Reject if expiration tag is absent or exceeded
+2. Validate HMAC auth tag (silent drop on failure)
+3. Discard if rider is muted
+4. Suppress if driver is already `AVAILABLE` or `IN_RIDE` (ping redundant)
+5. Apply rate limits: per-rider 30 s spam throttle + global cap of 2 per 10-min rolling window
+
+_Kind 3189 is part of the RoadFlare extension (Issue #4). Drivestr implementation plan: `docs/plans/2026-04-14-issue-4-driver-ping-receiver.md`._
 
 ---
 

--- a/docs/protocol/NOSTR_EVENTS.md
+++ b/docs/protocol/NOSTR_EVENTS.md
@@ -1192,10 +1192,13 @@ _Kind 30013 (Shareable Driver List): Reserved for future use — not yet impleme
 {
   "action":    "ping",
   "riderName": "<rider's display name>",
-  "message":   "<riderName> is currently hoping you come online!",
   "timestamp": 1706300000
 }
 ```
+
+> **Security — `message` field removed (deprecated):** An earlier version of this spec included a `message` field containing a pre-formatted notification string. This was removed because NIP-44 + HMAC auth only proves "approved follower," not "honest sender." Any follower with the RoadFlare key can craft a custom client and set `message` to arbitrary text, which would appear verbatim on the driver's lock screen as a system notification.
+>
+> **Receiver behaviour:** The `message` field MUST be ignored if present (iOS may send it during the transition window). The notification body MUST be constructed locally: `"<sanitised riderName> is hoping you come online"`. `riderName` is itself sanitised at parse time (64-char truncation, control-character strip) to limit the attack surface of the remaining sender-controlled display-name field.
 
 **Auth Tag**:
 

--- a/drivestr/src/main/java/com/drivestr/app/service/DriverPingRateLimiter.kt
+++ b/drivestr/src/main/java/com/drivestr/app/service/DriverPingRateLimiter.kt
@@ -1,0 +1,83 @@
+package com.drivestr.app.service
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Rate limiter for incoming Kind 3189 driver ping notifications.
+ *
+ * Enforces two independent limits (per protocol spec §1.5):
+ * - Per-rider 30-second notification spam throttle (prevents a single rider from generating multiple notifications in rapid succession)
+ * - Global cap of 2 notifications per 10-minute rolling window
+ *
+ * Both limits are applied after HMAC auth validation — [tryAccept] is only called
+ * for events that already passed [RoadflareDriverPingEvent.parseAndDecrypt].
+ *
+ * Thread-safe: [tryAccept] is @Synchronized.
+ * [nowMs] is injectable for deterministic unit testing.
+ *
+ * State is intentionally in-memory only. Process restart clears all limits; this is
+ * acceptable because the global cap is 2 notifications per 10 minutes and a driver
+ * restarting mid-window is effectively starting a new session.
+ */
+class DriverPingRateLimiter(
+    private val nowMs: () -> Long = System::currentTimeMillis
+) {
+    companion object {
+        const val RIDER_DEDUP_WINDOW_MS     = 30_000L    // 30 seconds
+        const val GLOBAL_WINDOW_MS          = 600_000L   // 10 minutes
+        const val GLOBAL_MAX_NOTIFICATIONS  = 2
+    }
+
+    // Per-rider: maps riderPubKey → timestamp (ms) of last accepted ping
+    private val riderLastAccepted = ConcurrentHashMap<String, Long>()
+
+    // Global rolling window: timestamps (ms) of accepted notifications, oldest first
+    // Guarded by `this` via @Synchronized on tryAccept
+    private val globalTimestamps = ArrayDeque<Long>()
+
+    /**
+     * Try to accept a ping from [riderPubKey].
+     *
+     * Records a notification slot and returns true if the ping should be delivered.
+     * Returns false if it should be silently dropped (dedup or cap).
+     *
+     * IMPORTANT: call this ONLY after all suppression checks (presence gate, mute) have
+     * passed. Rate-limit slots must not be consumed by events that will be suppressed anyway.
+     */
+    @Synchronized
+    fun tryAccept(riderPubKey: String): Boolean {
+        val now = nowMs()
+
+        // 1. Per-rider 30 s dedup
+        val lastSeen = riderLastAccepted[riderPubKey]
+        if (lastSeen != null && (now - lastSeen) < RIDER_DEDUP_WINDOW_MS) {
+            return false
+        }
+
+        // 2. Global rolling window: evict entries older than GLOBAL_WINDOW_MS
+        val windowStart = now - GLOBAL_WINDOW_MS
+        while (globalTimestamps.isNotEmpty() && globalTimestamps.first() < windowStart) {
+            globalTimestamps.removeFirst()
+        }
+        if (globalTimestamps.size >= GLOBAL_MAX_NOTIFICATIONS) {
+            return false
+        }
+
+        // Accept — record timestamps
+        riderLastAccepted[riderPubKey] = now
+        globalTimestamps.addLast(now)
+        return true
+    }
+
+    /**
+     * Reset all rate-limit state.
+     *
+     * Call from [RoadflareListenerService.stopListening] so that stale slots from a previous
+     * service run do not bleed into the next one (e.g. service killed and restarted mid-ride).
+     */
+    @Synchronized
+    fun reset() {
+        riderLastAccepted.clear()
+        globalTimestamps.clear()
+    }
+}

--- a/drivestr/src/main/java/com/drivestr/app/service/RoadflareListenerService.kt
+++ b/drivestr/src/main/java/com/drivestr/app/service/RoadflareListenerService.kt
@@ -224,7 +224,10 @@ class RoadflareListenerService : Service() {
     private fun subscribeToDriverPings(driverPubKey: String) {
         pingSubscriptionId = nostrService?.relayManager?.subscribe(
             kinds = listOf(RideshareEventKinds.ROADFLARE_DRIVER_PING),
-            tags  = mapOf("p" to listOf(driverPubKey))
+            tags  = mapOf(
+                "p" to listOf(driverPubKey),
+                "t" to listOf(RoadflareDriverPingEvent.T_TAG)
+            )
         ) { event, _ ->
             // Event-id dedup: seenRequests is shared with Kind 3173 — event IDs are globally unique
             if (!seenRequests.add(event.id)) return@subscribe
@@ -381,7 +384,7 @@ class RoadflareListenerService : Service() {
 
         // Build notification body locally — never use a sender-supplied string.
         // riderName is already sanitised (truncated + control-char stripped) at parse time.
-        val body = "${pingData.riderName} is hoping you come online"
+        val body = "${pingData.riderName.ifEmpty { "Someone" }} is hoping you come online"
         val notification = NotificationHelper.buildDriverStatusNotification(
             context       = this,
             contentIntent = createContentIntent(),

--- a/drivestr/src/main/java/com/drivestr/app/service/RoadflareListenerService.kt
+++ b/drivestr/src/main/java/com/drivestr/app/service/RoadflareListenerService.kt
@@ -13,6 +13,8 @@ import com.ridestr.common.data.DriverRoadflareRepository
 import com.ridestr.common.nostr.NostrService
 import com.ridestr.common.nostr.events.RideOfferEvent
 import com.ridestr.common.nostr.events.RideshareEventKinds
+import com.ridestr.common.nostr.events.RoadflareDriverPingData
+import com.ridestr.common.nostr.events.RoadflareDriverPingEvent
 import com.drivestr.app.presence.DriverPresenceGate
 import com.drivestr.app.presence.DriverPresenceStore
 import com.ridestr.common.notification.NotificationHelper
@@ -56,6 +58,13 @@ class RoadflareListenerService : Service() {
         const val NOTIFICATION_ID_ROADFLARE_LISTENER = 3001
         const val NOTIFICATION_ID_ROADFLARE_REQUEST = 3002
 
+        // Base ID for driver ping notifications. Each rider gets a unique slot:
+        // NOTIFICATION_ID_DRIVER_PING + abs(riderPubKey.hashCode() % 10000).
+        // Range: [14001, 24000]. Chosen to avoid collision with follow-notification IDs
+        // at NOTIFICATION_ID_FOLLOW_REQUEST + [0, 10000) = [3001, 13000].
+        // This mirrors the follow-notification pattern in MainActivity.kt:394.
+        const val NOTIFICATION_ID_DRIVER_PING = 14001
+
         // Default sats/USD rate for fare display
         private const val DEFAULT_SATS_PER_DOLLAR = 2000.0
 
@@ -94,6 +103,8 @@ class RoadflareListenerService : Service() {
     private val serviceScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     private var subscriptionJob: Job? = null
     private var subscriptionId: String? = null
+    private var pingSubscriptionId: String? = null
+    private val pingRateLimiter = DriverPingRateLimiter()
 
     // Track received requests to avoid duplicate notifications
     private val seenRequests = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
@@ -163,6 +174,9 @@ class RoadflareListenerService : Service() {
                 // Subscribe to Kind 3173 events where we're in p-tags and have roadflare tag
                 subscribeToRoadflareRequests(driverPubKey)
 
+                // Subscribe to Kind 3189 driver pings
+                subscribeToDriverPings(driverPubKey)
+
             } catch (e: Exception) {
                 Log.e(TAG, "Error starting listener", e)
             }
@@ -205,6 +219,71 @@ class RoadflareListenerService : Service() {
         }
 
         Log.d(TAG, "Subscribed with ID: $subscriptionId")
+    }
+
+    private fun subscribeToDriverPings(driverPubKey: String) {
+        pingSubscriptionId = nostrService?.relayManager?.subscribe(
+            kinds = listOf(RideshareEventKinds.ROADFLARE_DRIVER_PING),
+            tags  = mapOf("p" to listOf(driverPubKey))
+        ) { event, _ ->
+            // Event-id dedup: seenRequests is shared with Kind 3173 — event IDs are globally unique
+            if (!seenRequests.add(event.id)) return@subscribe
+
+            serviceScope.launch {
+                processPingEvent(event, driverPubKey)
+            }
+        }
+        Log.d(TAG, "Subscribed to driver pings: $pingSubscriptionId")
+    }
+
+    private suspend fun processPingEvent(
+        event: Event,
+        driverPubKey: String
+    ) {
+        val signer = nostrService?.keyManager?.getSigner() ?: return
+        val roadflareKey = driverRoadflareRepo?.getRoadflareKey() ?: run {
+            Log.d(TAG, "No RoadFlare key — cannot validate ping HMAC; dropping")
+            return
+        }
+
+        // Validate HMAC + expiry + decrypt (null = any failure = silent drop)
+        val pingData = RoadflareDriverPingEvent.parseAndDecrypt(
+            signer              = signer,
+            event               = event,
+            driverPubKey        = driverPubKey,
+            roadflarePrivKeyHex = roadflareKey.privateKey
+        ) ?: return
+
+        // Mute check — after HMAC auth, before notification (spec §1.5).
+        // Live fetch from repository so mute changes take effect immediately without
+        // requiring a service restart (unlike the Kind 3173 snapshot approach).
+        // O(n) in muted-count per event; acceptable up to ~200 muted pubkeys.
+        // Revisit with a cached snapshot if drivers report >1000 followers or high muted counts.
+        val mutedPubkeys = driverRoadflareRepo?.getMutedPubkeys() ?: emptySet()
+        if (event.pubKey in mutedPubkeys) {
+            Log.d(TAG, "Discarding authenticated ping from muted rider ${event.pubKey.take(8)}")
+            return
+        }
+
+        // Suppression ordering (MUST be: mute → presence gate → tryAccept):
+        // Rate-limit slots must not be consumed by events that would be suppressed by mute
+        // or by driver presence (AVAILABLE / IN_RIDE), so both gates run BEFORE tryAccept().
+        val gate = presenceStore.gate.value
+        // gate is StateFlow<DriverPresenceGate?> — null = state unknown (app just started), treat as offline → show notification.
+        // AVAILABLE / IN_RIDE: suppress — driver is publicly visible, ping is redundant.
+        // ROADFLARE_ONLY: do NOT suppress — driver is privately broadcasting to followers only; ping is still relevant.
+        if (gate == DriverPresenceGate.AVAILABLE || gate == DriverPresenceGate.IN_RIDE) {
+            Log.d(TAG, "Driver is online ($gate) — skipping ping notification")
+            return
+        }
+
+        // Rate limit + per-rider dedup — called last, after all suppression checks
+        if (!pingRateLimiter.tryAccept(event.pubKey)) {
+            Log.d(TAG, "Driver ping rate-limited from ${event.pubKey.take(8)}")
+            return
+        }
+
+        showPingNotification(pingData)
     }
 
     private suspend fun processRoadflareRequest(event: Event) {
@@ -295,12 +374,46 @@ class RoadflareListenerService : Service() {
         Log.d(TAG, "Showed notification: $content")
     }
 
+    private fun showPingNotification(pingData: RoadflareDriverPingData) {
+        val soundEnabled     = settingsRepository.getNotificationSoundEnabled()
+        val vibrationEnabled = settingsRepository.getNotificationVibrationEnabled()
+        SoundManager.playRideRequestAlert(this, soundEnabled, vibrationEnabled)
+
+        val notification = NotificationHelper.buildDriverStatusNotification(
+            context       = this,
+            contentIntent = createContentIntent(),
+            title         = "Driver Ping",
+            content       = pingData.message,
+            isHighPriority = true,
+            isOngoing     = false,
+            channel       = NotificationHelper.CHANNEL_DRIVER_PING
+        )
+        // Per-rider stable ID (base + abs(pubkeyHash % 10_000)) — mirrors MainActivity.kt:394.
+        // Each rider gets a distinct tray slot so two accepted pings within the 10-min window
+        // are visible simultaneously. Birthday paradox: ~130 unique riders for 1% collision
+        // probability; acceptable for typical follower counts (<50). Collisions cause one
+        // notification to replace another in the tray — no crash, no data loss.
+        val notificationId = NOTIFICATION_ID_DRIVER_PING +
+            kotlin.math.abs(pingData.riderPubKey.hashCode() % 10000)
+        NotificationHelper.showNotification(
+            context        = this,
+            notificationId = notificationId,
+            notification   = notification
+        )
+        Log.d(TAG, "Showed driver ping notification (id=$notificationId): ${pingData.message.take(60)}")
+    }
+
     private fun stopListening() {
         subscriptionJob?.cancel()
         subscriptionId?.let { id ->
             nostrService?.relayManager?.closeSubscription(id)
         }
         subscriptionId = null
+        pingSubscriptionId?.let { id ->
+            nostrService?.relayManager?.closeSubscription(id)
+        }
+        pingSubscriptionId = null
+        pingRateLimiter.reset()   // clear slots so a service restart begins from a clean state
         // Don't disconnect the singleton — other components share relay connections
         seenRequests.clear()
         riderNameCache.clear()

--- a/drivestr/src/main/java/com/drivestr/app/service/RoadflareListenerService.kt
+++ b/drivestr/src/main/java/com/drivestr/app/service/RoadflareListenerService.kt
@@ -60,9 +60,11 @@ class RoadflareListenerService : Service() {
 
         // Base ID for driver ping notifications. Each rider gets a unique slot:
         // NOTIFICATION_ID_DRIVER_PING + abs(riderPubKey.hashCode() % 10000).
-        // Range: [14001, 24000]. Chosen to avoid collision with follow-notification IDs
-        // at NOTIFICATION_ID_FOLLOW_REQUEST + [0, 10000) = [3001, 13000].
-        // This mirrors the follow-notification pattern in MainActivity.kt:394.
+        // Range: [14001, 24000].
+        // Note: [3001, 13000] is occupied by NOTIFICATION_ID_ROADFLARE_LISTENER (3001),
+        // NOTIFICATION_ID_ROADFLARE_REQUEST (3002), and follow-request dynamic IDs
+        // (NOTIFICATION_ID_FOLLOW_REQUEST + abs(hash % 10000)). Chosen to be clear of all of these.
+        // Mirrors the follow-notification pattern in MainActivity.kt:394.
         const val NOTIFICATION_ID_DRIVER_PING = 14001
 
         // Default sats/USD rate for fare display
@@ -222,6 +224,7 @@ class RoadflareListenerService : Service() {
     }
 
     private fun subscribeToDriverPings(driverPubKey: String) {
+        pingSubscriptionId?.let { nostrService?.relayManager?.closeSubscription(it) }
         pingSubscriptionId = nostrService?.relayManager?.subscribe(
             kinds = listOf(RideshareEventKinds.ROADFLARE_DRIVER_PING),
             tags  = mapOf(

--- a/drivestr/src/main/java/com/drivestr/app/service/RoadflareListenerService.kt
+++ b/drivestr/src/main/java/com/drivestr/app/service/RoadflareListenerService.kt
@@ -388,12 +388,16 @@ class RoadflareListenerService : Service() {
         // Build notification body locally — never use a sender-supplied string.
         // riderName is already sanitised (truncated + control-char stripped) at parse time.
         val body = "${pingData.riderName.ifEmpty { "Someone" }} is hoping you come online"
+        // isHighPriority = false: on API 26+ channel importance is the sole heads-up gate
+        // and CHANNEL_DRIVER_PING is IMPORTANCE_DEFAULT (silent tray notification pattern,
+        // SoundManager already handled the alert tone above). Passing true would set a
+        // PRIORITY_HIGH that Android silently ignores and misreads caller intent.
         val notification = NotificationHelper.buildDriverStatusNotification(
             context       = this,
             contentIntent = createContentIntent(),
             title         = "Driver Ping",
             content       = body,
-            isHighPriority = true,
+            isHighPriority = false,
             isOngoing     = false,
             channel       = NotificationHelper.CHANNEL_DRIVER_PING
         )

--- a/drivestr/src/main/java/com/drivestr/app/service/RoadflareListenerService.kt
+++ b/drivestr/src/main/java/com/drivestr/app/service/RoadflareListenerService.kt
@@ -379,11 +379,14 @@ class RoadflareListenerService : Service() {
         val vibrationEnabled = settingsRepository.getNotificationVibrationEnabled()
         SoundManager.playRideRequestAlert(this, soundEnabled, vibrationEnabled)
 
+        // Build notification body locally — never use a sender-supplied string.
+        // riderName is already sanitised (truncated + control-char stripped) at parse time.
+        val body = "${pingData.riderName} is hoping you come online"
         val notification = NotificationHelper.buildDriverStatusNotification(
             context       = this,
             contentIntent = createContentIntent(),
             title         = "Driver Ping",
-            content       = pingData.message,
+            content       = body,
             isHighPriority = true,
             isOngoing     = false,
             channel       = NotificationHelper.CHANNEL_DRIVER_PING
@@ -400,7 +403,7 @@ class RoadflareListenerService : Service() {
             notificationId = notificationId,
             notification   = notification
         )
-        Log.d(TAG, "Showed driver ping notification (id=$notificationId): ${pingData.message.take(60)}")
+        Log.d(TAG, "Showed driver ping notification (id=$notificationId): ${body.take(60)}")
     }
 
     private fun stopListening() {

--- a/drivestr/src/test/java/com/drivestr/app/service/DriverPingRateLimiterTest.kt
+++ b/drivestr/src/test/java/com/drivestr/app/service/DriverPingRateLimiterTest.kt
@@ -1,0 +1,93 @@
+package com.drivestr.app.service
+
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class DriverPingRateLimiterTest {
+
+    private var fakeNow = 1_000_000L  // arbitrary stable start time
+    private lateinit var limiter: DriverPingRateLimiter
+
+    @Before
+    fun setUp() {
+        fakeNow = 1_000_000L
+        limiter = DriverPingRateLimiter(nowMs = { fakeNow })
+    }
+
+    // ── Per-rider 30 s dedup ─────────────────────────────────────────────────
+
+    @Test
+    fun `tryAccept allows first ping from rider`() {
+        assertTrue(limiter.tryAccept("rider_A"))
+    }
+
+    @Test
+    fun `tryAccept drops duplicate within 30 seconds`() {
+        assertTrue(limiter.tryAccept("rider_A"))
+        fakeNow += 29_000L  // 29 s later — still within window
+        assertFalse(limiter.tryAccept("rider_A"))
+    }
+
+    @Test
+    fun `tryAccept allows ping after 30 seconds have elapsed`() {
+        assertTrue(limiter.tryAccept("rider_A"))
+        fakeNow += 30_001L  // just past the 30 s window
+        assertTrue(limiter.tryAccept("rider_A"))
+    }
+
+    @Test
+    fun `tryAccept per-rider dedup does not affect different riders`() {
+        assertTrue(limiter.tryAccept("rider_A"))
+        assertTrue(limiter.tryAccept("rider_B"))  // different pubkey → independent window
+    }
+
+    // ── Global 2-per-10-min cap ──────────────────────────────────────────────
+
+    @Test
+    fun `tryAccept enforces global cap of 2 per 10 minutes`() {
+        // 1st ping (rider_A)
+        assertTrue(limiter.tryAccept("rider_A"))
+        fakeNow += 31_000L  // >30 s so rider dedup clears between calls below
+
+        // 2nd ping (rider_B) — still within 10-min global window
+        assertTrue(limiter.tryAccept("rider_B"))
+        fakeNow += 31_000L
+
+        // 3rd ping (rider_C) — global cap exceeded
+        assertFalse(limiter.tryAccept("rider_C"))
+    }
+
+    @Test
+    fun `tryAccept allows again after 10-minute global window rolls past first entry`() {
+        assertTrue(limiter.tryAccept("rider_A"))   // recorded at 1_000_000
+        fakeNow += 31_000L
+        assertTrue(limiter.tryAccept("rider_B"))   // recorded at 1_031_000 — now at cap
+        // Advance so the 1_000_000 entry falls outside the 10-min window:
+        // windowStart = fakeNow - 600_000 must exceed 1_000_000 → fakeNow > 1_600_000
+        fakeNow = 1_600_001L
+        assertTrue(limiter.tryAccept("rider_C"))   // first entry evicted; count=1 < 2 → allowed
+    }
+
+    // ── reset() ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `reset clears all state allowing immediate acceptance`() {
+        // Fill dedup for rider_A and reach global cap within the same 10-min window.
+        // fakeNow starts at 1_000_000 (from setUp).
+        assertTrue(limiter.tryAccept("rider_A"))   // slot 1; rider_A dedup window starts
+        fakeNow += 5_000L                           // only 5 s — rider_A is still within 30 s dedup
+        assertTrue(limiter.tryAccept("rider_B"))   // slot 2; global cap (2) reached
+
+        // Confirm both limits are blocking before reset
+        assertFalse(limiter.tryAccept("rider_A"))  // per-rider dedup active: 5 s < 30 s
+        assertFalse(limiter.tryAccept("rider_C"))  // global cap active
+
+        limiter.reset()
+
+        // Per-rider dedup cleared → rider_A accepted immediately (5 s has NOT elapsed naturally)
+        assertTrue(limiter.tryAccept("rider_A"))
+        // Global cap cleared → rider_C also accepted
+        assertTrue(limiter.tryAccept("rider_C"))
+    }
+}


### PR DESCRIPTION
## Summary

- **Kind 3189 `driverPingRequest`**: new Nostr event that lets a rider nudge an offline trusted driver to come online via their RoadFlare network
- **`RoadflareDriverPingEvent`** (`common`): stateless validation pipeline — kind check, NIP-40 expiry, 3-window HMAC-SHA256 auth, NIP-44 decrypt (14 Robolectric tests)
- **`DriverPingRateLimiter`** (`drivestr`): per-rider 30 s spam throttle + 2-per-10-min global rolling cap, injectable clock for determinism (7 JUnit4 tests)
- **`RoadflareListenerService`**: new Kind 3189 subscription alongside existing 3173; suppression ordering mute → presence gate → `tryAccept()`; `NOTIFICATION_ID_DRIVER_PING` range [14001, 24000]
- **`CHANNEL_DRIVER_PING`** (`"driver_ping"`): new notification channel with operator-controllable settings
- **`NOSTR_EVENTS.md`**: Kind 3189 section + range expressions updated from `3186-3188` → `3186-3189`

## Test Plan

- [ ] 14 ping event tests pass: `./gradlew :common:testDebugUnitTest` — `RoadflareDriverPingEventTest`
- [ ] 7 rate-limiter tests pass: `./gradlew :drivestr:testDebugUnitTest` — `DriverPingRateLimiterTest`
- [ ] Full debug build: `./gradlew :common:assembleDebug :drivestr:assembleDebug`
- [ ] Manual: install drivestr on device, go offline (ROADFLARE_ONLY or OFFLINE), have a follower send a Kind 3189 ping → notification appears
- [ ] Manual: driver `AVAILABLE` or `IN_RIDE` → ping notification suppressed
- [ ] Open Question #2 (pre-ship): cross-platform HMAC smoke test with iOS sender

## Notes

- iOS sender implementation runs in parallel on `roadflare-ios` branch `claude/issue-4-driver-ping`; both PRs should merge in lockstep (either order is safe — graceful degradation if one side lags)
- Protocol spec is locked; see ADR-0009 in `roadflare-ios` repo for architectural rationale

🤖 Generated with [Claude Code](https://claude.com/claude-code)