### PR TITLE
feat(rider): encode authoritative fiat fare in outgoing offers

### DIFF
--- a/common/src/main/java/com/ridestr/common/nostr/RideOfferSpec.kt
+++ b/common/src/main/java/com/ridestr/common/nostr/RideOfferSpec.kt
@@ -23,7 +23,10 @@ sealed class RideOfferSpec {
         val rideRoute: RouteMetrics?,
         val mintUrl: String?,
         val paymentMethod: String,
-        val fiatPaymentMethods: List<String> = emptyList()
+        val fiatPaymentMethods: List<String> = emptyList(),
+        // Authoritative fiat fare per ADR-0008 (both-or-neither)
+        val fareFiatAmount: String? = null,
+        val fareFiatCurrency: String? = null
     ) : RideOfferSpec()
 
     /** RoadFlare offer to a followed driver. No availability event reference. */
@@ -37,7 +40,10 @@ sealed class RideOfferSpec {
         val rideRoute: RouteMetrics?,
         val mintUrl: String?,
         val paymentMethod: String,
-        val fiatPaymentMethods: List<String> = emptyList()
+        val fiatPaymentMethods: List<String> = emptyList(),
+        // Authoritative fiat fare per ADR-0008 (both-or-neither)
+        val fareFiatAmount: String? = null,
+        val fareFiatCurrency: String? = null
     ) : RideOfferSpec()
 
     /** Public broadcast visible to all drivers in pickup area. Precise locations —
@@ -48,7 +54,10 @@ sealed class RideOfferSpec {
         val fareEstimate: Double,
         val routeDistance: RouteMetrics,  // Required for broadcasts
         val mintUrl: String?,
-        val paymentMethod: String
+        val paymentMethod: String,
+        // Authoritative fiat fare per ADR-0008 (both-or-neither)
+        val fareFiatAmount: String? = null,
+        val fareFiatCurrency: String? = null
     ) : RideOfferSpec()
 }
 

--- a/common/src/main/java/com/ridestr/common/nostr/RideshareDomainService.kt
+++ b/common/src/main/java/com/ridestr/common/nostr/RideshareDomainService.kt
@@ -248,7 +248,10 @@ class RideshareDomainService(
         mintUrl: String? = null,
         paymentMethod: String? = "cashu",
         isRoadflare: Boolean = false,
-        fiatPaymentMethods: List<String> = emptyList()
+        fiatPaymentMethods: List<String> = emptyList(),
+        // Authoritative fiat fare per ADR-0008 (both-or-neither)
+        fareFiatAmount: String? = null,
+        fareFiatCurrency: String? = null
     ): String? {
         val signer = keyManager.getSigner()
         if (signer == null) {
@@ -271,7 +274,9 @@ class RideshareDomainService(
                 mintUrl = mintUrl,
                 paymentMethod = paymentMethod ?: "cashu",
                 isRoadflare = isRoadflare,
-                fiatPaymentMethods = fiatPaymentMethods
+                fiatPaymentMethods = fiatPaymentMethods,
+                fareFiatAmount = fareFiatAmount,
+                fareFiatCurrency = fareFiatCurrency
             )
             relayManager.publish(event)
             val offerType = if (isRoadflare) "RoadFlare" else "ride"
@@ -298,7 +303,9 @@ class RideshareDomainService(
             mintUrl = spec.mintUrl,
             paymentMethod = spec.paymentMethod,
             isRoadflare = false,
-            fiatPaymentMethods = spec.fiatPaymentMethods
+            fiatPaymentMethods = spec.fiatPaymentMethods,
+            fareFiatAmount = spec.fareFiatAmount,
+            fareFiatCurrency = spec.fareFiatCurrency
         )
         is RideOfferSpec.RoadFlare -> sendRideOffer(
             driverPubKey = spec.driverPubKey,
@@ -313,7 +320,9 @@ class RideshareDomainService(
             mintUrl = spec.mintUrl,
             paymentMethod = spec.paymentMethod,
             isRoadflare = true,
-            fiatPaymentMethods = spec.fiatPaymentMethods
+            fiatPaymentMethods = spec.fiatPaymentMethods,
+            fareFiatAmount = spec.fareFiatAmount,
+            fareFiatCurrency = spec.fareFiatCurrency
         )
         is RideOfferSpec.Broadcast -> broadcastRideRequest(
             pickup = spec.pickup,
@@ -322,7 +331,9 @@ class RideshareDomainService(
             routeDistanceKm = spec.routeDistance.distanceKm,
             routeDurationMin = spec.routeDistance.durationMin,
             mintUrl = spec.mintUrl,
-            paymentMethod = spec.paymentMethod
+            paymentMethod = spec.paymentMethod,
+            fareFiatAmount = spec.fareFiatAmount,
+            fareFiatCurrency = spec.fareFiatCurrency
         )
     }
 
@@ -344,7 +355,10 @@ class RideshareDomainService(
         routeDistanceKm: Double,
         routeDurationMin: Double,
         mintUrl: String? = null,
-        paymentMethod: String = "cashu"
+        paymentMethod: String = "cashu",
+        // Authoritative fiat fare per ADR-0008 (both-or-neither)
+        fareFiatAmount: String? = null,
+        fareFiatCurrency: String? = null
     ): String? {
         val signer = keyManager.getSigner()
         if (signer == null) {
@@ -361,7 +375,9 @@ class RideshareDomainService(
                 routeDistanceKm = routeDistanceKm,
                 routeDurationMin = routeDurationMin,
                 mintUrl = mintUrl,
-                paymentMethod = paymentMethod
+                paymentMethod = paymentMethod,
+                fareFiatAmount = fareFiatAmount,
+                fareFiatCurrency = fareFiatCurrency
             )
             relayManager.publish(event)
             Log.d(TAG, "Broadcast ride request: ${event.id} (fare=$fareEstimate sats, method=$paymentMethod)")

--- a/common/src/main/java/com/ridestr/common/nostr/events/RideOfferEvent.kt
+++ b/common/src/main/java/com/ridestr/common/nostr/events/RideOfferEvent.kt
@@ -46,7 +46,10 @@ object RideOfferEvent {
         routeDurationMin: Double,
         mintUrl: String? = null,
         paymentMethod: String = "cashu",
-        isRoadflare: Boolean = false
+        isRoadflare: Boolean = false,
+        // Authoritative fiat fare per ADR-0008 - both-or-neither
+        fareFiatAmount: String? = null,
+        fareFiatCurrency: String? = null
     ): Event {
         val content = JSONObject().apply {
             put("fare_estimate", fareEstimate)
@@ -57,6 +60,11 @@ object RideOfferEvent {
             // Multi-mint support (Issue #13)
             mintUrl?.let { put("mint_url", it) }
             put("payment_method", paymentMethod)
+            // Authoritative fiat fare per ADR-0008 (both-or-neither rule)
+            if (fareFiatAmount != null && fareFiatCurrency != null) {
+                put("fare_fiat_amount", fareFiatAmount)
+                put("fare_fiat_currency", fareFiatCurrency)
+            }
         }.toString()
 
         // Build tags with geohash for geographic filtering
@@ -127,7 +135,10 @@ object RideOfferEvent {
         mintUrl: String? = null,
         paymentMethod: String = "cashu",
         isRoadflare: Boolean = false,
-        fiatPaymentMethods: List<String> = emptyList()
+        fiatPaymentMethods: List<String> = emptyList(),
+        // Authoritative fiat fare per ADR-0008 - both-or-neither
+        fareFiatAmount: String? = null,
+        fareFiatCurrency: String? = null
     ): Event {
         // Build plaintext content
         val plaintext = JSONObject().apply {
@@ -147,6 +158,11 @@ object RideOfferEvent {
             // Fiat payment methods in priority order (Issue #46)
             if (fiatPaymentMethods.isNotEmpty()) {
                 put("fiat_payment_methods", JSONArray(fiatPaymentMethods))
+            }
+            // Authoritative fiat fare per ADR-0008 (both-or-neither rule)
+            if (fareFiatAmount != null && fareFiatCurrency != null) {
+                put("fare_fiat_amount", fareFiatAmount)
+                put("fare_fiat_currency", fareFiatCurrency)
             }
         }.toString()
 

--- a/common/src/test/java/com/ridestr/common/RoadflareWiringTest.kt
+++ b/common/src/test/java/com/ridestr/common/RoadflareWiringTest.kt
@@ -292,6 +292,38 @@ class RoadflareWiringTest {
         assertTrue("Expected p-tag for driver", pTags.isNotEmpty())
     }
 
+    @Test
+    fun `create direct offer includes authoritative fiat fields when both values are present`() = runBlocking {
+        val tagsSlot = slot<Array<Array<String>>>()
+        val plaintextSlot = slot<String>()
+        val mockSigner = mockk<NostrSigner>(relaxed = true)
+        val mockEvent = mockk<Event>(relaxed = true)
+
+        coEvery { mockSigner.nip44Encrypt(capture(plaintextSlot), any()) } returns "encrypted_content"
+        coEvery {
+            mockSigner.sign<Event>(
+                createdAt = any(),
+                kind = any(),
+                tags = capture(tagsSlot),
+                content = any()
+            )
+        } returns mockEvent
+
+        RideOfferEvent.create(
+            signer = mockSigner,
+            driverPubKey = "abc123driver",
+            pickup = Location(36.0, -115.0),
+            destination = Location(36.1, -115.1),
+            fareEstimate = 10.0,
+            fareFiatAmount = "12.50",
+            fareFiatCurrency = "USD"
+        )
+
+        val json = JSONObject(plaintextSlot.captured)
+        assertEquals("12.50", json.getString("fare_fiat_amount"))
+        assertEquals("USD", json.getString("fare_fiat_currency"))
+    }
+
     // ==================
     // Broadcast offer path (geographic discovery)
     // ==================
@@ -357,5 +389,37 @@ class RoadflareWiringTest {
         // Should have geohash tags at precision 3, 4, and 5
         assertTrue("Expected geohash tags, got none", gTags.isNotEmpty())
         assertTrue("Expected at least 3 geohash tags (precision 3-5)", gTags.size >= 3)
+    }
+
+    @Test
+    fun `createBroadcast omits authoritative fiat fields unless both values are present`() = runBlocking {
+        val tagsSlot = slot<Array<Array<String>>>()
+        val contentSlot = slot<String>()
+        val mockSigner = mockk<NostrSigner>(relaxed = true)
+        val mockEvent = mockk<Event>(relaxed = true)
+
+        coEvery {
+            mockSigner.sign<Event>(
+                createdAt = any(),
+                kind = any(),
+                tags = capture(tagsSlot),
+                content = capture(contentSlot)
+            )
+        } returns mockEvent
+
+        RideOfferEvent.createBroadcast(
+            signer = mockSigner,
+            pickup = Location(36.0, -115.0),
+            destination = Location(36.1, -115.1),
+            fareEstimate = 10.0,
+            routeDistanceKm = 12.0,
+            routeDurationMin = 15.0,
+            fareFiatAmount = "12.50",
+            fareFiatCurrency = null
+        )
+
+        val json = JSONObject(contentSlot.captured)
+        assertFalse(json.has("fare_fiat_amount"))
+        assertFalse(json.has("fare_fiat_currency"))
     }
 }

--- a/rider-app/src/main/java/com/ridestr/rider/viewmodels/AuthoritativeFareQuote.kt
+++ b/rider-app/src/main/java/com/ridestr/rider/viewmodels/AuthoritativeFareQuote.kt
@@ -1,0 +1,21 @@
+package com.ridestr.rider.viewmodels
+
+import java.util.Locale
+
+internal data class AuthoritativeFareQuote(
+    val sats: Double,
+    val usdAmount: String
+)
+
+/**
+ * Build a fare quote where USD remains authoritative for fiat/manual rails,
+ * even when sats falls back heuristically because BTC price lookup failed.
+ */
+internal fun authoritativeFareQuote(
+    fareUsd: Double,
+    sats: Long?,
+    fallbackSats: Double
+): AuthoritativeFareQuote = AuthoritativeFareQuote(
+    sats = sats?.toDouble() ?: fallbackSats,
+    usdAmount = String.format(Locale.US, "%.2f", fareUsd)
+)

--- a/rider-app/src/main/java/com/ridestr/rider/viewmodels/RiderViewModel.kt
+++ b/rider-app/src/main/java/com/ridestr/rider/viewmodels/RiderViewModel.kt
@@ -167,7 +167,27 @@ class RiderViewModel @Inject constructor(
         val roadflareTargetLocation: Location?,
         // Fiat payment methods in rider's priority order (Issue #46)
         val fiatPaymentMethods: List<String> = emptyList(),
+        // Authoritative fiat fare per ADR-0008 (set when paymentMethod is fiat rail)
+        val fareFiatAmount: String? = null,
+        val fareFiatCurrency: String? = null,
     )
+
+    /**
+     * Result of a fare calculation. Carries both sats (always) and the original USD value
+     * used to compute it (null when BTC price was unavailable and a fallback was used).
+     * The USD value is the authoritative fiat amount per ADR-0008.
+     */
+    private data class FareCalc(val sats: Double, val usdAmount: String?)
+
+    /**
+     * Per ADR-0008, fiat fare fields are encoded only for fiat payment rails.
+     * Crypto rails (cashu/lightning) skip the fields — sats is canonical there.
+     */
+    private fun isFiatPaymentMethod(paymentMethod: String): Boolean =
+        paymentMethod !in setOf(
+            com.ridestr.common.nostr.events.PaymentMethod.CASHU.value,
+            com.ridestr.common.nostr.events.PaymentMethod.LIGHTNING.value
+        )
 
     private val prefs = application.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     private val nostrService = NostrService.getInstance(application, settingsRepository.getEffectiveRelays())
@@ -559,17 +579,19 @@ class RiderViewModel @Inject constructor(
         confirmationInFlight.set(false)  // Allow confirmation for next ride
         _uiState.update { current ->
             // Recalculate fare from route at current BTC price (Issue #51)
-            val freshFare = if (current.routeResult != null) {
+            val freshCalc = if (current.routeResult != null) {
                 calculateFare(current.routeResult)
             } else {
                 null  // No route = no fare (addresses were cleared)
             }
+            val freshFare = freshCalc?.sats
             val freshFareWithFees = freshFare?.let { it * (1 + FEE_BUFFER_PERCENT) }
 
             current.copy(
                 rideSession = RiderRideSession(rideStage = stage),
                 fareEstimate = freshFare,
                 fareEstimateWithFees = freshFareWithFees,
+                fareEstimateUsd = freshCalc?.usdAmount,
                 statusMessage = statusMessage,
                 error = error
             )
@@ -1644,7 +1666,9 @@ class RiderViewModel @Inject constructor(
                 rideRoute = rideMetrics,
                 mintUrl = riderMintUrl,
                 paymentMethod = params.paymentMethod,
-                fiatPaymentMethods = params.fiatPaymentMethods
+                fiatPaymentMethods = params.fiatPaymentMethods,
+                fareFiatAmount = params.fareFiatAmount,
+                fareFiatCurrency = params.fareFiatCurrency
             )
         } else {
             RideOfferSpec.Direct(
@@ -1657,7 +1681,9 @@ class RiderViewModel @Inject constructor(
                 rideRoute = rideMetrics,
                 mintUrl = riderMintUrl,
                 paymentMethod = params.paymentMethod,
-                fiatPaymentMethods = params.fiatPaymentMethods
+                fiatPaymentMethods = params.fiatPaymentMethods,
+                fareFiatAmount = params.fareFiatAmount,
+                fareFiatCurrency = params.fareFiatCurrency
             )
         }
         return nostrService.sendOffer(spec)
@@ -1823,6 +1849,11 @@ class RiderViewModel @Inject constructor(
         val destination = state.destination ?: return
         val fareEstimate = state.fareEstimate ?: return
         val fareWithBuffer = (fareEstimate * (1 + FEE_BUFFER_PERCENT)).toLong()
+        val paymentMethod = settingsRepository.getDefaultPaymentMethod()
+        // Encode authoritative fiat fare only for fiat rails (per ADR-0008)
+        val (offerFiatAmount, offerFiatCurrency) = if (isFiatPaymentMethod(paymentMethod) && state.fareEstimateUsd != null) {
+            state.fareEstimateUsd to "USD"
+        } else null to null
 
         updateRideSession { copy(isSendingOffer = true) }
         viewModelScope.launch {
@@ -1840,10 +1871,12 @@ class RiderViewModel @Inject constructor(
                 pickup = pickup, destination = destination,
                 fareEstimate = fareEstimate, rideRoute = state.routeResult,
                 preimage = preimage, paymentHash = paymentHash,
-                paymentMethod = settingsRepository.getDefaultPaymentMethod(),
+                paymentMethod = paymentMethod,
                 isRoadflare = false, isBroadcast = false,
                 statusMessage = "Waiting for driver to accept...",
-                roadflareTargetPubKey = null, roadflareTargetLocation = null
+                roadflareTargetPubKey = null, roadflareTargetLocation = null,
+                fareFiatAmount = offerFiatAmount,
+                fareFiatCurrency = offerFiatCurrency
             )
 
             val pickupRoute = calculatePickupRoute(driver.approxLocation, pickup)
@@ -1871,14 +1904,21 @@ class RiderViewModel @Inject constructor(
         val destination = state.destination ?: return
         val rideRoute = state.routeResult
 
-        val fareEstimate = if (driverLocation != null) {
+        val fareCalc: FareCalc = if (driverLocation != null) {
             calculateRoadflareFare(pickup, driverLocation, rideRoute)
-        } else { state.fareEstimate ?: return }
+        } else {
+            FareCalc(state.fareEstimate ?: return, state.fareEstimateUsd)
+        }
+        val fareEstimate = fareCalc.sats
 
         val paymentMethod = settingsRepository.getDefaultPaymentMethod()
         val fiatMethods = if (paymentMethod != com.ridestr.common.nostr.events.PaymentMethod.CASHU.value) {
             settingsRepository.getRoadflarePaymentMethods()
         } else emptyList()
+        // Encode authoritative fiat fare only for fiat rails (per ADR-0008)
+        val (offerFiatAmount, offerFiatCurrency) = if (isFiatPaymentMethod(paymentMethod) && fareCalc.usdAmount != null) {
+            fareCalc.usdAmount to "USD"
+        } else null to null
 
         // Sync balance check — only meaningful for cashu (non-cashu skips HTLC escrow)
         if (paymentMethod == com.ridestr.common.nostr.events.PaymentMethod.CASHU.value) {
@@ -1926,7 +1966,9 @@ class RiderViewModel @Inject constructor(
                 isRoadflare = true, isBroadcast = false,
                 statusMessage = "Waiting for driver to accept...",
                 roadflareTargetPubKey = driverPubKey, roadflareTargetLocation = driverLocation,
-                fiatPaymentMethods = fiatMethods
+                fiatPaymentMethods = fiatMethods,
+                fareFiatAmount = offerFiatAmount,
+                fareFiatCurrency = offerFiatCurrency
             )
 
             val pickupRoute = calculatePickupRoute(driverLocation, pickup)
@@ -1954,9 +1996,16 @@ class RiderViewModel @Inject constructor(
         val destination = state.destination ?: return
         val rideRoute = state.routeResult
 
-        val fareEstimate = if (driverLocation != null) {
+        val fareCalc: FareCalc = if (driverLocation != null) {
             calculateRoadflareFare(pickup, driverLocation, rideRoute)
-        } else { state.fareEstimate ?: return }
+        } else {
+            FareCalc(state.fareEstimate ?: return, state.fareEstimateUsd)
+        }
+        val fareEstimate = fareCalc.sats
+        // Encode authoritative fiat fare only for fiat rails (per ADR-0008)
+        val (offerFiatAmount, offerFiatCurrency) = if (isFiatPaymentMethod(paymentMethod) && fareCalc.usdAmount != null) {
+            fareCalc.usdAmount to "USD"
+        } else null to null
 
         // Clear the pending state
         _uiState.value = _uiState.value.copy(
@@ -1983,7 +2032,9 @@ class RiderViewModel @Inject constructor(
                 isRoadflare = true, isBroadcast = false,
                 statusMessage = "Waiting for driver to accept...",
                 roadflareTargetPubKey = driverPubKey, roadflareTargetLocation = driverLocation,
-                fiatPaymentMethods = settingsRepository.getRoadflarePaymentMethods()
+                fiatPaymentMethods = settingsRepository.getRoadflarePaymentMethods(),
+                fareFiatAmount = offerFiatAmount,
+                fareFiatCurrency = offerFiatCurrency
             )
 
             val pickupRoute = calculatePickupRoute(driverLocation, pickup)
@@ -2174,7 +2225,7 @@ class RiderViewModel @Inject constructor(
                 var maxFareSats = 0.0
                 for (dwr in cappedDrivers) {
                     val loc = dwr.location ?: continue
-                    val fareSats = calculateRoadflareFareWithRoute(pickup, loc, rideRoute, dwr.pickupRoute)
+                    val fareSats = calculateRoadflareFareWithRoute(pickup, loc, rideRoute, dwr.pickupRoute).sats
                     if (fareSats > maxFareSats) maxFareSats = fareSats
                 }
                 val fareWithBuffer = (maxFareSats * (1 + FEE_BUFFER_PERCENT)).toLong()
@@ -2314,11 +2365,12 @@ class RiderViewModel @Inject constructor(
             rideRoute = state.routeResult
         }
 
-        val fareEstimate = if (driverLocation != null) {
+        val fareCalc: FareCalc = if (driverLocation != null) {
             calculateRoadflareFareWithRoute(pickup, driverLocation, rideRoute, preCalculatedRoute)
         } else {
-            state.fareEstimate ?: return
+            FareCalc(state.fareEstimate ?: return, state.fareEstimateUsd)
         }
+        val fareEstimate = fareCalc.sats
 
         // Only generate HTLC for Bitcoin payment — alternates have no escrow
         val (preimage, paymentHash) = if (paymentMethod == com.ridestr.common.nostr.events.PaymentMethod.CASHU.value) {
@@ -2334,6 +2386,10 @@ class RiderViewModel @Inject constructor(
         val fiatMethods = if (paymentMethod != com.ridestr.common.nostr.events.PaymentMethod.CASHU.value) {
             settingsRepository.getRoadflarePaymentMethods()
         } else emptyList()
+        // Encode authoritative fiat fare only for fiat rails (per ADR-0008)
+        val (offerFiatAmount, offerFiatCurrency) = if (isFiatPaymentMethod(paymentMethod) && fareCalc.usdAmount != null) {
+            fareCalc.usdAmount to "USD"
+        } else null to null
 
         val params = OfferParams(
             driverPubKey = driverPubKey,
@@ -2346,7 +2402,9 @@ class RiderViewModel @Inject constructor(
             isRoadflare = true, isBroadcast = false,
             statusMessage = "",  // Batch doesn't set status per-offer
             roadflareTargetPubKey = driverPubKey, roadflareTargetLocation = driverLocation,
-            fiatPaymentMethods = fiatMethods
+            fiatPaymentMethods = fiatMethods,
+            fareFiatAmount = offerFiatAmount,
+            fareFiatCurrency = offerFiatCurrency
         )
 
         val eventId = sendOfferToNostr(params, pickupRoute)
@@ -2498,7 +2556,7 @@ class RiderViewModel @Inject constructor(
         pickup: Location,
         driverLocation: Location,
         rideRoute: RouteResult?
-    ): Double {
+    ): FareCalc {
         return calculateRoadflareFareWithRoute(pickup, driverLocation, rideRoute, null)
     }
 
@@ -2511,7 +2569,7 @@ class RiderViewModel @Inject constructor(
         driverLocation: Location,
         rideRoute: RouteResult?,
         pickupRoute: RouteResult?
-    ): Double {
+    ): FareCalc {
         val ROADFLARE_RATE_PER_MILE = remoteConfigManager.config.value.roadflareFareRateUsdPerMile
         val METERS_PER_MILE = 1609.34
 
@@ -2537,9 +2595,13 @@ class RiderViewModel @Inject constructor(
 
         // Convert USD to sats using live BTC price
         val sats = bitcoinPriceService.usdToSats(fareUsd)
-        // Fallback: 5000 sats when no BTC price available
+        // If BTC price unavailable, fall back and drop USD (cannot state USD equivalent reliably)
         val MINIMUM_FALLBACK_SATS = 5000.0
-        return sats?.toDouble() ?: MINIMUM_FALLBACK_SATS
+        return if (sats != null) {
+            FareCalc(sats = sats.toDouble(), usdAmount = String.format("%.2f", fareUsd))
+        } else {
+            FareCalc(sats = MINIMUM_FALLBACK_SATS, usdAmount = null)
+        }
     }
 
     /**
@@ -2659,12 +2721,15 @@ class RiderViewModel @Inject constructor(
             roadflareBatchJob = null
             subs.closeGroup(SubKeys.BATCH_ACCEPTANCE)  // Clean up any batch subs
 
-            // Update fare in state - reset timeout flag since we're boosting
+            // Update fare in state - reset timeout flag since we're boosting.
+            // Clear fareEstimateUsd: boost adds sats with no clean USD equivalent,
+            // so the boosted offer drops authoritative fiat fields (driver falls back to sats→USD).
             val newFareWithFeesDouble = newFare * (1 + FEE_BUFFER_PERCENT)
             _uiState.update { current ->
                 current.copy(
                     fareEstimate = newFare,
                     fareEstimateWithFees = newFareWithFeesDouble,
+                    fareEstimateUsd = null,
                     rideSession = current.rideSession.copy(
                         directOfferBoostSats = session.directOfferBoostSats + boostAmount,
                         pendingOfferEventId = null,
@@ -2693,6 +2758,7 @@ class RiderViewModel @Inject constructor(
                 fiatPaymentMethods = if (isRoadflare && paymentMethod != com.ridestr.common.nostr.events.PaymentMethod.CASHU.value) {
                     settingsRepository.getRoadflarePaymentMethods()
                 } else emptyList()
+                // Boosted offer: no fareFiatAmount/Currency — driver falls back to sats→USD for the boosted fare
             )
 
             val eventId = sendOfferToNostr(params, pickupRoute)
@@ -2766,6 +2832,10 @@ class RiderViewModel @Inject constructor(
 
             val riderMintUrl = walletService?.getSavedMintUrl()
             val paymentMethod = settingsRepository.getDefaultPaymentMethod()
+            // Encode authoritative fiat fare only for fiat rails (per ADR-0008)
+            val (offerFiatAmount, offerFiatCurrency) = if (isFiatPaymentMethod(paymentMethod) && state.fareEstimateUsd != null) {
+                state.fareEstimateUsd to "USD"
+            } else null to null
 
             // Precise locations — RideOfferEvent.createBroadcast() handles approximation internally
             val spec = RideOfferSpec.Broadcast(
@@ -2774,7 +2844,9 @@ class RiderViewModel @Inject constructor(
                 fareEstimate = fareEstimate,
                 routeDistance = RouteMetrics.fromSeconds(routeResult.distanceKm, routeResult.durationSeconds),
                 mintUrl = riderMintUrl,
-                paymentMethod = paymentMethod
+                paymentMethod = paymentMethod,
+                fareFiatAmount = offerFiatAmount,
+                fareFiatCurrency = offerFiatCurrency
             )
             val eventId = nostrService.sendOffer(spec)
 
@@ -5346,13 +5418,15 @@ class RiderViewModel @Inject constructor(
             )
 
             if (result != null) {
-                val fareEstimate = calculateFare(result)
+                val fareCalc = calculateFare(result)
+                val fareEstimate = fareCalc.sats
                 val fareEstimateWithFees = fareEstimate * (1 + FEE_BUFFER_PERCENT)
                 _uiState.value = _uiState.value.copy(
                     isCalculatingRoute = false,
                     routeResult = result,
                     fareEstimate = fareEstimate,
-                    fareEstimateWithFees = fareEstimateWithFees
+                    fareEstimateWithFees = fareEstimateWithFees,
+                    fareEstimateUsd = fareCalc.usdAmount
                 )
             } else {
                 _uiState.value = _uiState.value.copy(
@@ -5363,7 +5437,7 @@ class RiderViewModel @Inject constructor(
         }
     }
 
-    private fun calculateFare(route: RouteResult): Double {
+    private fun calculateFare(route: RouteResult): FareCalc {
         // Convert km to miles
         val distanceMiles = route.distanceKm * KM_TO_MILES
 
@@ -5381,10 +5455,14 @@ class RiderViewModel @Inject constructor(
         // Convert USD to sats using current BTC price
         val sats = bitcoinPriceService.usdToSats(fareUsd)
 
-        // Return sats, or fallback if price unavailable
-        // For fallback, calculate minimum based on config minimum fare (assuming ~$100k BTC)
+        // If BTC price is available, the USD value matches the sats value (authoritative).
+        // If unavailable, sats falls back and we cannot reliably state the USD equivalent.
         val minimumFallbackSats = minimumFare * 1000.0  // $1 = ~1000 sats at $100k BTC
-        return sats?.toDouble() ?: maxOf(distanceMiles * FALLBACK_SATS_PER_MILE, minimumFallbackSats)
+        return if (sats != null) {
+            FareCalc(sats = sats.toDouble(), usdAmount = String.format("%.2f", fareUsd))
+        } else {
+            FareCalc(sats = maxOf(distanceMiles * FALLBACK_SATS_PER_MILE, minimumFallbackSats), usdAmount = null)
+        }
     }
 
     /**
@@ -5615,6 +5693,7 @@ data class RiderUiState(
     val routeResult: RouteResult? = null,
     val fareEstimate: Double? = null,             // Actual fare (sent to driver in offer)
     val fareEstimateWithFees: Double? = null,     // Displayed fare (fare + 2% buffer for cross-mint fees)
+    val fareEstimateUsd: String? = null,          // Authoritative USD fare (per ADR-0008) — encoded in fiat offers; null after boost/process death
     val isCalculatingRoute: Boolean = false,
     val isRoutingReady: Boolean = false,
 

--- a/rider-app/src/main/java/com/ridestr/rider/viewmodels/RiderViewModel.kt
+++ b/rider-app/src/main/java/com/ridestr/rider/viewmodels/RiderViewModel.kt
@@ -173,9 +173,8 @@ class RiderViewModel @Inject constructor(
     )
 
     /**
-     * Result of a fare calculation. Carries both sats (always) and the original USD value
-     * used to compute it (null when BTC price was unavailable and a fallback was used).
-     * The USD value is the authoritative fiat amount per ADR-0008.
+     * Result of a fare calculation. Carries sats (actual or heuristic fallback) and the
+     * authoritative USD quote used for fiat/manual offers.
      */
     private data class FareCalc(val sats: Double, val usdAmount: String?)
 
@@ -2593,15 +2592,16 @@ class RiderViewModel @Inject constructor(
         val calculatedFare = (driverToPickupMiles + rideMiles) * ROADFLARE_RATE_PER_MILE
         val fareUsd = maxOf(calculatedFare, minimumFareUsd)
 
-        // Convert USD to sats using live BTC price
+        // Convert USD to sats using live BTC price. If price lookup fails, keep the
+        // authoritative USD quote for fiat/manual rails and fall back only for sats.
         val sats = bitcoinPriceService.usdToSats(fareUsd)
-        // If BTC price unavailable, fall back and drop USD (cannot state USD equivalent reliably)
         val MINIMUM_FALLBACK_SATS = 5000.0
-        return if (sats != null) {
-            FareCalc(sats = sats.toDouble(), usdAmount = String.format("%.2f", fareUsd))
-        } else {
-            FareCalc(sats = MINIMUM_FALLBACK_SATS, usdAmount = null)
-        }
+        val quote = authoritativeFareQuote(
+            fareUsd = fareUsd,
+            sats = sats,
+            fallbackSats = MINIMUM_FALLBACK_SATS
+        )
+        return FareCalc(sats = quote.sats, usdAmount = quote.usdAmount)
     }
 
     /**
@@ -2926,7 +2926,9 @@ class RiderViewModel @Inject constructor(
             subs.close(SubKeys.ACCEPTANCE)
             subs.closeGroup(SubKeys.BATCH_ACCEPTANCE)  // Defensive no-op (broadcast stage, not batch)
 
-            // Update fare in state - store actual sats boosted (not count)
+            // Update fare in state - store actual sats boosted (not count).
+            // Clear fareEstimateUsd: boost adds raw sats with no clean USD equivalent,
+            // so the boosted broadcast should drop authoritative fiat fields.
             // Reset broadcastTimedOut AND broadcastStartTimeMs to prevent race condition with UI
             // The explicit null reset ensures LaunchedEffect properly restarts when new time is set
             val newFareWithFees = newFare * (1 + FEE_BUFFER_PERCENT)
@@ -2934,6 +2936,7 @@ class RiderViewModel @Inject constructor(
                 current.copy(
                     fareEstimate = newFare,
                     fareEstimateWithFees = newFareWithFees,
+                    fareEstimateUsd = null,
                     rideSession = current.rideSession.copy(
                         totalBoostSats = session.totalBoostSats + boostAmount,
                         pendingOfferEventId = null,
@@ -5452,17 +5455,17 @@ class RiderViewModel @Inject constructor(
         // Enforce minimum fare to ensure driver profitability on short rides
         val fareUsd = maxOf(distanceBasedFare, minimumFare)
 
-        // Convert USD to sats using current BTC price
+        // Convert USD to sats using current BTC price. If price lookup fails, keep the
+        // authoritative USD quote for fiat/manual rails and fall back only for sats.
         val sats = bitcoinPriceService.usdToSats(fareUsd)
 
-        // If BTC price is available, the USD value matches the sats value (authoritative).
-        // If unavailable, sats falls back and we cannot reliably state the USD equivalent.
         val minimumFallbackSats = minimumFare * 1000.0  // $1 = ~1000 sats at $100k BTC
-        return if (sats != null) {
-            FareCalc(sats = sats.toDouble(), usdAmount = String.format("%.2f", fareUsd))
-        } else {
-            FareCalc(sats = maxOf(distanceMiles * FALLBACK_SATS_PER_MILE, minimumFallbackSats), usdAmount = null)
-        }
+        val quote = authoritativeFareQuote(
+            fareUsd = fareUsd,
+            sats = sats,
+            fallbackSats = maxOf(distanceMiles * FALLBACK_SATS_PER_MILE, minimumFallbackSats)
+        )
+        return FareCalc(sats = quote.sats, usdAmount = quote.usdAmount)
     }
 
     /**

--- a/rider-app/src/test/java/com/ridestr/rider/viewmodels/AuthoritativeFareQuoteTest.kt
+++ b/rider-app/src/test/java/com/ridestr/rider/viewmodels/AuthoritativeFareQuoteTest.kt
@@ -1,0 +1,37 @@
+package com.ridestr.rider.viewmodels
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.Locale
+
+class AuthoritativeFareQuoteTest {
+
+    @Test
+    fun `fallback keeps authoritative usd amount`() {
+        val quote = authoritativeFareQuote(
+            fareUsd = 12.345,
+            sats = null,
+            fallbackSats = 5000.0
+        )
+
+        assertEquals(5000.0, quote.sats, 0.001)
+        assertEquals("12.35", quote.usdAmount)
+    }
+
+    @Test
+    fun `authoritative usd amount uses protocol stable decimal formatting`() {
+        val originalLocale = Locale.getDefault()
+        Locale.setDefault(Locale.FRANCE)
+        try {
+            val quote = authoritativeFareQuote(
+                fareUsd = 12.5,
+                sats = 1234L,
+                fallbackSats = 5000.0
+            )
+
+            assertEquals("12.50", quote.usdAmount)
+        } finally {
+            Locale.setDefault(originalLocale)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the fiat fare fix (stacks on #61). Phase 1 made drivestr READ `fare_fiat_amount` + `fare_fiat_currency` from incoming Kind 3173 events. **This phase makes the Android rider-app SEND those fields**, so Android-rider → Drivestr flows also display the rider's exact fiat amount (not a sats→USD reconversion).

## Threading

`calculateFare()` and `calculateRoadflareFareWithRoute()` now return `FareCalc(sats, usdAmount)`. The `usdAmount` preserves the quote-time USD value (per ADR-0008 \"rider's exact intended amount\") and flows through:

```
calculateFare → RiderUiState.fareEstimateUsd
              → OfferParams.fareFiatAmount/Currency
              → RideOfferSpec.{Direct,RoadFlare,Broadcast}
              → RideshareDomainService.{sendRideOffer,broadcastRideRequest}
              → RideOfferEvent.{create,createBroadcast}
              → encoded JSON: fare_fiat_amount + fare_fiat_currency
```

## Encoding Gate

Fiat fields are only included when `paymentMethod` is a fiat rail (not `\"cashu\"` / `\"lightning\"`). Both-or-neither rule per ADR-0008. Centralized in `isFiatPaymentMethod()` helper.

## Boost & Process Death

- **Boost** (`boostFare()`): clears `fareEstimateUsd` — the boost adds raw sats with no clean USD equivalent. The boosted offer drops fiat fields → driver falls back to sats→USD for that one offer.
- **Process death**: `fareEstimateUsd` is not persisted. Restored offers drop fiat fields, same fallback as boost.

## Out of Scope (deferred)

- **Rider-side `FareDisplay` update** — rider's display still uses live sats→USD conversion. Slight UX mismatch: rider sees live \$X.YZ, encodes calc-time \$X.YZ. Defer to UX polish PR.
- **Tests** — no existing `RideOfferEvent` test infrastructure. Add in separate test-coverage PR.
- **Other currencies** — hardcoded \"USD\" only. Future enhancement.

## Files Changed

- `common/.../events/RideOfferEvent.kt` — `create()` and `createBroadcast()` accept and encode `fareFiatAmount` / `fareFiatCurrency` (both-or-neither)
- `common/.../nostr/RideOfferSpec.kt` — all 3 variants (`Direct`, `RoadFlare`, `Broadcast`) carry the new fields
- `common/.../nostr/RideshareDomainService.kt` — `sendRideOffer()` / `broadcastRideRequest()` thread params through; `sendOffer(spec)` dispatch wires from spec
- `rider-app/.../RiderViewModel.kt`:
  - New private `FareCalc(sats, usdAmount)` data class returned by both calc functions
  - Helper `isFiatPaymentMethod(paymentMethod)` for the encoding gate
  - `RiderUiState.fareEstimateUsd: String?` (set by calc functions, cleared by boost)
  - `OfferParams` carries `fareFiatAmount` / `fareFiatCurrency`
  - Updated 6 OfferParams construction sites + Broadcast spec construction site
  - `boostFare()` explicitly clears `fareEstimateUsd`

## Test plan

- [ ] **Android rider sends Cashu offer**: drivestr displays sats→USD. No regression.
- [ ] **Android rider sends fiat (zelle/paypal/cash) offer**: drivestr displays the rider's exact fiat amount end-to-end (offer card, ride flow, completion).
- [ ] **BTC price drift during test**: drivestr's display matches the rider's quoted USD, regardless of when driver receives the event.
- [ ] **Boost on fiat ride**: boosted offer falls back to sats→USD on driver side (acceptable drift on boost only).
- [ ] **iOS-rider → Drivestr** (Phase 1 path): still works — no regression.
- [x] `./gradlew :rider-app:assembleDebug :drivestr:assembleDebug` builds cleanly with no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)