### PR TITLE
docs: document fiat fare fields (ADR-0008) and Kind 3189 driver ping

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -136,7 +136,7 @@ See [docs/README.md](../docs/README.md) for full documentation.
 | Kind | Type | Purpose |
 |------|------|---------|
 | 30173 | Addressable | Driver Availability Broadcast + mint_url/payment_methods |
-| 3173 | Regular | Ride Offer (rider → driver) + mint_url/payment_method |
+| 3173 | Regular | Ride Offer (rider → driver) + mint_url/payment_method + fare_fiat_amount/currency (ADR-0008) |
 | 3174 | Regular | Ride Acceptance (driver → rider) + mint_url/payment_method |
 | 3175 | Regular | Ride Confirmation (rider → driver, with paymentHash + escrowToken) |
 | 30180 | Param. Replaceable | Driver Ride State (status, PIN, settlement) |
@@ -166,6 +166,7 @@ See [docs/README.md](../docs/README.md) for full documentation.
 | 3186 | Regular | Key Share (driver→follower DM, 5-min expiry) |
 | 3187 | Regular | Follow Notification (short expiry, real-time UX; p-tag query is primary) |
 | 3188 | Regular | Key Acknowledgement (confirm receipt or refresh request) |
+| 3189 | Regular | Driver Ping Request (rider asks driver to come online; HMAC-authenticated, 30-min TTL) |
 
 ## RoadFlare Architecture
 
@@ -207,6 +208,13 @@ PENDING → APPROVED → KEY_SENT → ACTIVE
 | Cross-device sync | `DriverViewModel.kt` | `ensureRoadflareStateSynced()` |
 | Stale key detection | `RoadflareTab.kt` | `checkStaleKeys()` |
 | Key refresh handler | `MainActivity.kt` | Kind 3188 handler - rider sends `status="stale"`, driver re-sends key |
+| Driver ping listener | `RoadflareListenerService.kt` | Kind 3189 subscription, HMAC validation, silent-tray notification |
+| Ping rate limiting | `DriverPingRateLimiter.kt` | 30s per-rider dedup + global 2/10min cap |
+
+### Driver Ping (Kind 3189, Issue #4)
+Riders can ping a followed driver to ask them to come online. Encoded with `roadflare-ping`
+HMAC for authentication (only approved followers can ping). Driver receives a silent
+heads-up notification (CHANNEL_DRIVER_PING). Rate limited to prevent spam.
 
 ## Payment System
 
@@ -230,6 +238,16 @@ Driver's `wallet_pubkey` in Kind 3174 ensures HTLC is locked to correct key. If 
 ### ⚠️ CRITICAL: PaymentHash is in Kind 3175, NOT Kind 3173
 
 **PaymentHash is in confirmation (Kind 3175), NOT offer (Kind 3173).** This is intentional - HTLC must lock AFTER acceptance to use driver's wallet_pubkey. Do NOT move paymentHash back to offer events.
+
+### Authoritative Fiat Fare (ADR-0008)
+
+**For fiat-rail rides only** (`payment_method` not in `{cashu, lightning}`), Kind 3173 carries `fare_fiat_amount` (decimal string) and `fare_fiat_currency` (ISO 4217). Both-or-neither rule. These are the authoritative display value — driver shows them directly without sats→USD conversion. Fixes ~$1 drift caused by independent BTC price conversions on each side.
+
+**Encoding flow:** `RiderViewModel.calculateFare()` returns `FareCalc(sats, usdAmount)` → `RiderUiState.fareEstimateUsd` → `OfferParams` → `RideOfferSpec` → `RideshareDomainService` → `RideOfferEvent.create()` JSON.
+
+**Boost behavior:** `boostFare()` clears `fareEstimateUsd` — boosted offer drops fiat fields, driver falls back to sats→USD for that one offer (acceptable drift on boost only).
+
+**Compatible with roadflare-ios per ADR-0008** (identical field names + semantics).
 
 ### Deferred HTLC Locking
 
@@ -321,7 +339,9 @@ Multi-relay delivery of acceptance events causes concurrent `autoConfirmRide()` 
 - `RideshareDomainService.kt` - Ride protocol events (Kind 3173-3179, 30173, 30180-30181)
 - `NostrCryptoHelper.kt` - NIP-44 encryption utilities
 - `ProfileBackupService.kt` - Profile and history backup (Kind 30174, 30177)
-- `RoadflareDomainService.kt` - RoadFlare events (Kind 30011, 30012, 30014, 3186, 3188)
+- `RoadflareDomainService.kt` - RoadFlare events (Kind 30011, 30012, 30014, 3186, 3188, 3189)
+- `RoadflareListenerService.kt` - Driver-side foreground service; subscribes to Kind 3189 driver pings + RoadFlare follow notifications
+- `DriverPingRateLimiter.kt` - 30s per-rider dedup + global 2/10min cap on Kind 3189 ping notifications
 
 ### State Machine
 - `common/.../state/RideState.kt` - Unified state enum
@@ -414,7 +434,7 @@ Relay message → RelayConnection.handleMessage()
 | Event | Fields |
 |-------|--------|
 | Kind 30173 (Availability) | `mint_url`, `payment_methods[]` |
-| Kind 3173 (Offer) | `mint_url`, `payment_method` |
+| Kind 3173 (Offer) | `mint_url`, `payment_method`, `fare_fiat_amount`, `fare_fiat_currency` |
 | Kind 3174 (Acceptance) | `mint_url`, `payment_method` |
 | Kind 30177 (Profile) | `settings.paymentMethods[]`, `settings.defaultPaymentMethod`, `settings.mintUrl` |
 

--- a/docs/CONNECTIONS.md
+++ b/docs/CONNECTIONS.md
@@ -1,8 +1,12 @@
 # Ridestr Module Connections
 
-**Last Updated**: 2026-02-25 (Issue #46: Payment method priority ordering, fiat_payment_methods wiring, ReorderablePaymentMethodList)
+**Last Updated**: 2026-04-16 (ADR-0008 fiat fare fields in Kind 3173, Kind 3189 driver ping receiver)
 
 This document provides a comprehensive view of how all modules connect in the Ridestr codebase. Use this as a reference when making changes to understand what might be affected.
+
+**April 2026 Changes:**
+- Kind 3173 ride offer events now carry `fare_fiat_amount` + `fare_fiat_currency` for fiat-rail rides (per ADR-0008). Both rider-app encoding and drivestr decoding wired end-to-end. See [`docs/protocol/NOSTR_EVENTS.md#kind-3173-ride-offer`](protocol/NOSTR_EVENTS.md#kind-3173-ride-offer).
+- New Kind 3189 RoadFlare Driver Ping receiver. Drivers run `RoadflareListenerService` to receive ping notifications from approved followers asking them to come online. HMAC-authenticated, 30-min TTL, rate-limited via `DriverPingRateLimiter` (30s per-rider dedup + global 2/10min cap).
 
 **Phase 5 Changes (February 2026):**
 - NostrService split into domain services (facade pattern for backward compatibility)

--- a/docs/protocol/NOSTR_EVENTS.md
+++ b/docs/protocol/NOSTR_EVENTS.md
@@ -1,7 +1,7 @@
 # Ridestr Nostr Event Protocol
 
-**Version**: 1.8
-**Last Updated**: 2026-02-25
+**Version**: 1.9
+**Last Updated**: 2026-04-16
 
 This document defines all Nostr event kinds used in the Ridestr rideshare application.
 
@@ -420,7 +420,9 @@ All three tiers use Kind 3173. Detection: broadcast = has `["t", "ride-request"]
   "ride_route_min": 18,
   "mint_url": "<cashu_mint_url>",
   "payment_method": "cashu",
-  "fiat_payment_methods": ["zelle", "venmo", "paypal"]
+  "fiat_payment_methods": ["zelle", "venmo", "paypal"],
+  "fare_fiat_amount": "12.50",
+  "fare_fiat_currency": "USD"
 }
 ```
 
@@ -433,7 +435,9 @@ All three tiers use Kind 3173. Detection: broadcast = has `["t", "ride-request"]
   "route_distance_km": 12.3,
   "route_duration_min": 18,
   "mint_url": "<cashu_mint_url>",
-  "payment_method": "cashu"
+  "payment_method": "cashu",
+  "fare_fiat_amount": "12.50",
+  "fare_fiat_currency": "USD"
 }
 ```
 
@@ -445,6 +449,26 @@ All three tiers use Kind 3173. Detection: broadcast = has `["t", "ride-request"]
 
 **RoadFlare Payment Priority Fields** (Issue #46):
 - `fiat_payment_methods`: Rider's ordered RoadFlare alternate payment methods (e.g., `["zelle", "venmo"]`). Driver uses `findBestCommonFiatMethod()` to select best common method. Omitted when empty. Not included in broadcast offers (privacy — broadcast content is plaintext).
+
+**Authoritative Fiat Fare Fields** (ADR-0008, April 2026):
+- `fare_fiat_amount`: Decimal string of the rider's exact intended fiat amount (e.g., `"12.50"`).
+- `fare_fiat_currency`: ISO 4217 currency code (e.g., `"USD"`).
+
+**Both-or-neither rule.** Either both fields are present together or both are absent. A
+partial pair MUST be treated as if neither were sent.
+
+**When encoded:** Only when `payment_method` is a fiat rail (i.e., not `"cashu"` and not
+`"lightning"`). For crypto rails, sats is canonical and these fields MUST be absent.
+
+**Why:** Both rider and driver convert sats↔USD using their own local BTC price. Even small
+price drift between offer creation and display caused ~\$1 discrepancies. When present,
+`fare_fiat_amount` is the authoritative display value for the receiver — no BTC conversion
+needed. `fare_estimate` (sats) is retained for backward compatibility; older clients that
+don't parse the fiat fields fall back to sats→USD conversion (with the original drift, but
+no breakage).
+
+**Compatibility:** Fields are additive. Older clients silently ignore unknown JSON keys.
+Compatible with roadflare-ios per ADR-0008 (identical field names and semantics).
 
 **Note**: Precise coordinates are NOT shared in the offer. Only revealed progressively after confirmation.
 


### PR DESCRIPTION
## Summary

Documentation refresh covering two recent protocol additions whose docs lagged behind the code merges.

### 1. Fiat fare fields on Kind 3173 (PRs #61 + #62, ADR-0008)
- \`fare_fiat_amount\` (decimal string) + \`fare_fiat_currency\` (ISO 4217)
- Both-or-neither rule
- Encoded only for fiat rails (not cashu/lightning)
- Authoritative display value — no BTC conversion drift
- Compatible with roadflare-ios per [ADR-0008](https://github.com/variablefate/roadflare-ios/blob/main/decisions/0008-fiat-fare-fields.md)

### 2. Kind 3189 RoadFlare Driver Ping (PR #60, Issue #4)
Already had an in-depth section in NOSTR_EVENTS.md but was missing from the at-a-glance tables in CLAUDE.md and CONNECTIONS.md.

## Files Changed

| File | Changes |
|------|---------|
| \`docs/protocol/NOSTR_EVENTS.md\` | Version 1.8 → 1.9; added \`fare_fiat_amount\` + \`fare_fiat_currency\` to Direct + Broadcast Kind 3173 JSON schemas; added \"Authoritative Fiat Fare Fields\" subsection explaining when/why/compatibility |
| \`docs/CONNECTIONS.md\` | Bumped Last Updated; added \"April 2026 Changes\" block summarizing both features |
| \`.claude/CLAUDE.md\` | Added Kind 3189 row to RoadFlare events table; updated Kind 3173 row + Multi-Mint fields table to mention fiat fare; added \`RoadflareListenerService\` + \`DriverPingRateLimiter\` to Key Files; new \"Driver Ping (Kind 3189)\" section under RoadFlare Architecture; new \"Authoritative Fiat Fare (ADR-0008)\" section under Payment System |

## What's Out of Scope

- **Viewmodel docs** (\`RIDER_VIEWMODEL.md\`, \`DRIVER_VIEWMODEL.md\`) timestamps are stale (Feb 2026) but content was not deeply audited. Bumping the dates without verifying content would be misleading. Defer to a dedicated audit.
- **Other architecture docs** (\`OVERVIEW.md\`, \`PAYMENT_ARCHITECTURE.md\`, \`STATE_MACHINES.md\`) — no references to fiat fare or Kind 3189 found, content appears current.
- **Code changes** — none. Documentation only.

## Test plan

- [x] Verify Kind 3189 in-depth section exists in NOSTR_EVENTS.md (lines ~1198)
- [x] Verify Kind 3189 referenced in summary table at top of NOSTR_EVENTS.md (line 27, range \`30011-30014, 3186-3189\`)
- [x] Verify fiat fare JSON schema additions are correct per ADR-0008 (decimal string + ISO 4217, both-or-neither)
- [x] Cross-check field names match roadflare-ios implementation (\`fare_fiat_amount\`, \`fare_fiat_currency\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)