### PR TITLE
fix(roadflare): remove active-followers gate from broadcastIfReady()

### DIFF
--- a/common/src/main/java/com/ridestr/common/roadflare/RoadflareLocationBroadcaster.kt
+++ b/common/src/main/java/com/ridestr/common/roadflare/RoadflareLocationBroadcaster.kt
@@ -20,8 +20,9 @@ import kotlinx.coroutines.flow.asStateFlow
  * to the driver's RoadFlare public key, which followers can decrypt using
  * the shared private key they received via Kind 3186.
  *
- * Broadcasting stops when:
- * - The driver has no RoadFlare key (no followers yet)
+ * Broadcasting skips when:
+ * - The driver has no RoadFlare key (not set up yet)
+ * - No location is available
  * - stopBroadcasting() is called (driver goes offline/app closed)
  *
  * Usage:
@@ -161,17 +162,12 @@ class RoadflareLocationBroadcaster(
             return
         }
 
-        // Check if we have any active followers
-        val activeFollowers = repository.getActiveFollowerPubkeys()
-        if (com.ridestr.common.BuildConfig.DEBUG) {
-            Log.d(TAG, "Broadcast check: ${activeFollowers.size} active followers")
-        }
-        if (activeFollowers.isEmpty()) {
-            if (com.ridestr.common.BuildConfig.DEBUG) {
-                Log.d(TAG, "No active followers, skipping broadcast")
-            }
-            return
-        }
+        // Note: no active-followers gate here by design. Transient empty windows
+        // (mid key rotation, cross-device restore before sync completes) would
+        // otherwise cause silent broadcast blackouts even with an established
+        // follower network. The encrypted payload is harmless when no follower
+        // can decrypt it, and the key check above already prevents broadcasting
+        // before RoadFlare is set up.
 
         // Get current location
         val location = locationProvider()


### PR DESCRIPTION
## Summary

- Removes the `if (activeFollowers.isEmpty()) return` gate from [`RoadflareLocationBroadcaster.broadcastIfReady()`](common/src/main/java/com/ridestr/common/roadflare/RoadflareLocationBroadcaster.kt) so transient empty-follower windows no longer cause silent broadcast blackouts.
- Updates the class KDoc header to reflect the actual skip conditions (no key / no location).

## Why

The gate assumed "empty follower list" always meant "don't bother broadcasting." In practice it can mean two very different things:

1. **Key-rotation window (mid-session bug).** After `rotateKey()`, every existing follower's `keyVersionSent` temporarily lags behind `currentVersion`, so `getActiveFollowerPubkeys()` returns empty until `markFollowerKeySent()` catches each one up via sequential Nostr round-trips. During that window, broadcast ticks silently skip despite a fully established network.
2. **Cross-device bootstrap race.** On a new device, state is restored from Kind 30012 via `ensureRoadflareStateSynced()` + the relay-connected `LaunchedEffect` auto-sync. The 120 s broadcast loop can tick once before the follower list is populated.

The encrypted Kind 30014 payload is harmless when no follower can decrypt it. Kind 30014 is a replaceable event (bounded relay storage), and the metadata signal \"this pubkey is alive\" is the same signal the driver already opts into by going RoadFlare-only or AVAILABLE. The remaining key + location guards still prevent broadcasts before RoadFlare is set up.

## Background

This is the broadcaster half of a stranded commit (`feea0c8` on a local branch). The companion `MainActivity` auto-sync `LaunchedEffect(isConnected)` hunk did land on main as `97205e2`, but the broadcaster hunk was dropped. The key-rotation scenario is not addressed by any other commit on main — only the removal of this gate fixes it.

## Fit with existing direction

- `b316004` replaced `isOnRide` flag with `statusProvider` lambda (fewer special cases in the broadcaster).
- `6e85f1d` \"force ONLINE broadcast after ride\" (always broadcast when online).
- `877f1bd` removed DND bullet from broadcaster KDoc.
- `97205e2` added auto-sync on relay connect.

This change continues that trend: the broadcaster becomes a simple \"key + location → broadcast\" primitive instead of a follower-list gatekeeper.

## Test plan

- [ ] Unit: no existing tests cover `broadcastIfReady()`; none break.
- [ ] Manual: verify a driver who goes RoadFlare-only continues to publish Kind 30014 during a `rotateKey()` → follower-reseed cycle.
- [ ] Manual: verify a fresh install → import key → go online publishes Kind 30014 even if the follower list populates after the first tick.

🤖 Generated with [Claude Code](https://claude.ai/code)