### PR TITLE
chore: post-refactor housekeeping + P1 fixes (#59, #71, #72)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -35,6 +35,9 @@ See [docs/README.md](../docs/README.md) for full documentation.
 | Batch Offer Cancellation | ✅ COMPLETE (NIP-09 deletion, payment method selection, balance precheck, FrozenRideInputs) |
 | Payment Method Priority (Issue #46) | ✅ COMPLETE (drag-to-reorder UI, fiat_payment_methods wiring, case-insensitive matching, driver-side compatibility indicator) |
 | Escrow Bypass Block | ✅ COMPLETE (rider blocks confirmation, driver hides "Complete Anyway" for SAME_MINT, process-death-stable paymentPath) |
+| Rider Coordinator Extraction (Issue #65) | ✅ COMPLETE (OfferCoordinator, PaymentCoordinator, RoadflareRiderCoordinator + AvailabilityMonitorPolicy in `:common/coordinator/`) |
+| Driver Coordinator Extraction (Issue #66) | ✅ COMPLETE (AvailabilityCoordinator, AcceptanceCoordinator, RoadflareDriverCoordinator in `:common/coordinator/`; PaymentStatus consolidated to `:common/payment/PaymentModels`) |
+| Compose Screen Decomposition (Issue #67) | ✅ COMPLETE (per-module `components/` packages: DriverModeScreenComponents, RideTabComponents, DriverNetworkComponents, HistoryComponents, SettingsComponents, ReorderablePaymentMethodList) |
 
 ## Project Structure
 - `rider-app/` - Rider Android app (RiderViewModel.kt is main state)
@@ -331,10 +334,38 @@ Multi-relay delivery of acceptance events causes concurrent `autoConfirmRide()` 
 
 ## Key Files Reference
 
+### Coordinators (`:common/coordinator/`)
+
+SDK-grade protocol extraction — no Hilt, no Context/ViewModel references, full KDoc on every public symbol. Each coordinator emits a SharedFlow of events consumed by its ViewModel.
+
+**Rider side (Issue #65):**
+- `OfferCoordinator.kt` - Offer sending (direct/broadcast/RoadFlare), batch offers, pre-confirmation driver availability monitoring (Issue #22)
+- `PaymentCoordinator.kt` - HTLC lock, Kind 3175 confirmation, escrow-bypass dialog, PIN verify, SAME_MINT preimage share, CROSS_MINT bridge + pending poll, post-confirm ack timeout, CAS race guards
+- `RoadflareRiderCoordinator.kt` - Kind 3186 key-share listener, Kind 3188 key-ack handling, Kind 3189 driver-ping
+- `AvailabilityMonitorPolicy.kt` - Pure policy object for pre-confirm driver availability monitoring
+
+**Driver side (Issue #66):**
+- `AvailabilityCoordinator.kt` - Kind 30173 broadcast loop, NIP-09 deletion, throttling
+- `AcceptanceCoordinator.kt` - Offer/broadcast accept, first-acceptance-wins CAS gate, PaymentPath determination
+- `RoadflareDriverCoordinator.kt` - State sync union-merge, Kind 30014 broadcasting, offline publish
+
+**Touching coordinators:** They're synthetic hotspots — the first bug fixes in them warrant extra care. Preserve the SDK-grade posture: visibility, KDoc, package boundaries.
+
+### Screen Components (Issue #67)
+
+Per-module `components/` packages decompose high-churn Compose screens into focused composables — pure UI code motion, no behavior change.
+
+- `drivestr/ui/screens/components/DriverModeScreenComponents.kt` - AvailabilityControls, OfferInbox, RoadflareFollowerList, RideOfferCard, BroadcastRideRequestCard, NoCommonPaymentMethodDialog, format helpers
+- `rider-app/ui/screens/components/` - HistoryList/FilterBar/EntryCard/StatsCard, RideRequestPanel, ActiveRidePanel, CompletionPanel, CancelDialogStack
+- `roadflare-rider/ui/screens/components/RideTabComponents.kt` - All ride-stage composables (IdleContent, RequestingContent, ChoosingDriverContent, MatchedContent, InRideContent, CompletedContent, CancelledContent) + `formatFareAmount`
+- `roadflare-rider/ui/screens/components/DriverNetworkComponents.kt` - FollowedDriverList, DriverCard, DriverStatusBadge, EmptyDriversState, RoadflarePaymentMethodsDialog
+- `common/ui/components/HistoryComponents.kt` - Shared history UI (HistoryList, HistoryFilterBar, HistoryEntryCard, HistoryStatsCard)
+- `common/ui/components/SettingsComponents.kt`, `ReorderablePaymentMethodList.kt` - Settings + drag-to-reorder payment methods
+
 ### Ride State Management
 - `SubscriptionManager.kt` - Centralized subscription ID lifecycle (`set()`, `close()`, `closeAll()`, `setInGroup()`, `closeGroup()`)
-- `DriverViewModel.kt` - `resetRideUiState()`, `closeAllRideSubscriptionsAndJobs()`, `clearDriverStateHistory()`, `acceptOffer()`, `acceptBroadcastRequest()`
-- `RiderViewModel.kt` - `resetRideUiState()`, `closeAllRideSubscriptionsAndJobs()`, `clearRiderStateHistory()`
+- `DriverViewModel.kt` - `resetRideUiState()`, `closeAllRideSubscriptionsAndJobs()`, `clearDriverStateHistory()`, `acceptOffer()`/`acceptBroadcastRequest()` (delegate to AcceptanceCoordinator)
+- `RiderViewModel.kt` - `resetRideUiState()`, `closeAllRideSubscriptionsAndJobs()`, `clearRiderStateHistory()` (ride protocol logic now owned by OfferCoordinator / PaymentCoordinator / RoadflareRiderCoordinator)
 - `NostrService.kt` - Facade that delegates to domain services (backward compatible)
 - `RideshareDomainService.kt` - Ride protocol events (Kind 3173-3179, 30173, 30180-30181)
 - `NostrCryptoHelper.kt` - NIP-44 encryption utilities

--- a/common/src/main/java/com/ridestr/common/fiat/FiatFareFormatting.kt
+++ b/common/src/main/java/com/ridestr/common/fiat/FiatFareFormatting.kt
@@ -24,6 +24,26 @@ fun FiatFare.usdAmountOrNull(): Double? = if (isUsd()) amount.toDoubleOrNull() e
 fun Double.formatUsd(prefix: String = ""): String =
     String.format(Locale.US, "%s$%.2f", prefix, this)
 
+/**
+ * Placeholder shown in SATS-display mode when no BTC price is available (cold start,
+ * network blip, relay outage). Visually distinct from any `$X.XX` formatting so the
+ * user can see their toggle choice was applied and understand conversion is pending
+ * rather than mistake the output for a dollar amount.
+ */
+const val SATS_PLACEHOLDER = "— sats"
+
+/**
+ * Format a sats value with a thousands separator (`12,345 sats`), or [SATS_PLACEHOLDER]
+ * when [sats] is null. Use when the caller is in SATS display mode and the sats value
+ * is derived from a USD amount via [com.ridestr.common.bitcoin.BitcoinPriceService.usdToSats] —
+ * a null result there means the price service hasn't populated a price yet, and callers
+ * MUST render the placeholder instead of silently falling back to USD formatting (which
+ * looks identical to USD mode and breaks the currency-toggle UX, see Issue #72).
+ */
+fun formatSatsOrPlaceholder(sats: Long?): String =
+    if (sats != null) String.format(Locale.US, "%,d sats", sats)
+    else SATS_PLACEHOLDER
+
 fun RideHistoryEntry.usdFareAmountOrNull(btcPriceUsd: Int?): Double? =
     fiatFare?.usdAmountOrNull()
         ?: btcPriceUsd?.takeIf { it > 0 }?.let { fareSats.toDouble() * it / 100_000_000.0 }

--- a/common/src/main/java/com/ridestr/common/nostr/events/FollowedDriversEvent.kt
+++ b/common/src/main/java/com/ridestr/common/nostr/events/FollowedDriversEvent.kt
@@ -1,5 +1,6 @@
 package com.ridestr.common.nostr.events
 
+import androidx.compose.runtime.Immutable
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import org.json.JSONArray
@@ -176,6 +177,7 @@ data class FollowedDriversData(
  * @param note Optional note about the driver (e.g., "Great driver, Toyota Camry")
  * @param roadflareKey The driver's RoadFlare key (needed to decrypt their location broadcasts)
  */
+@Immutable
 data class FollowedDriver(
     val pubkey: String,
     val addedAt: Long,

--- a/common/src/main/java/com/ridestr/common/nostr/events/RideOfferEvent.kt
+++ b/common/src/main/java/com/ridestr/common/nostr/events/RideOfferEvent.kt
@@ -1,6 +1,7 @@
 package com.ridestr.common.nostr.events
 
 import android.util.Log
+import androidx.compose.runtime.Immutable
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import org.json.JSONArray
@@ -468,7 +469,14 @@ data class RideOfferDataEncrypted(
 
 /**
  * Decrypted data from a DIRECT ride offer event (targeted to specific driver).
+ *
+ * `@Immutable` because ride offers are value-typed (parsed once from a Nostr event,
+ * never mutated) and passed through Compose UI (offer cards, inbox lists). The
+ * Compose compiler can't infer stability from the `List<String>` field
+ * (`fiatPaymentMethods`), so this annotation is necessary for `items { }` child
+ * skipping in the driver's offer inbox (see Issue #71).
  */
+@Immutable
 data class RideOfferData(
     val eventId: String,
     val riderPubKey: String,
@@ -499,7 +507,11 @@ data class RideOfferData(
 
 /**
  * Parsed data from a BROADCAST ride offer event (visible to all drivers in area).
+ *
+ * See [RideOfferData] for the `@Immutable` rationale — same reasoning applies to
+ * the `List<String>` geohashes field.
  */
+@Immutable
 data class BroadcastRideOfferData(
     val eventId: String,
     val riderPubKey: String,
@@ -527,4 +539,5 @@ data class BroadcastRideOfferData(
  * @param amount Decimal string (e.g., "12.50") — preserves rider's exact intended amount
  * @param currency ISO 4217 code (e.g., "USD")
  */
+@Immutable
 data class FiatFare(val amount: String, val currency: String)

--- a/common/src/main/java/com/ridestr/common/routing/ValhallaRoutingService.kt
+++ b/common/src/main/java/com/ridestr/common/routing/ValhallaRoutingService.kt
@@ -3,6 +3,7 @@ package com.ridestr.common.routing
 import ValhallaConfigBuilder
 import android.content.Context
 import android.util.Log
+import androidx.compose.runtime.Immutable
 import com.valhalla.api.models.CostingModel
 import com.valhalla.api.models.DirectionsOptions
 import com.valhalla.api.models.RouteRequest
@@ -233,7 +234,14 @@ class ValhallaRoutingService(private val context: Context) {
 
 /**
  * Result of a route calculation.
+ *
+ * `@Immutable` because `RouteResult` is a pure value — once the route is calculated
+ * it never mutates — and it flows through Compose UI (offer cards, maps). Without
+ * this annotation the `List<Maneuver>` field causes the Compose compiler to infer
+ * the whole class as unstable, which defeats child skipping in offer lists
+ * (Issue #71).
  */
+@Immutable
 data class RouteResult(
     val distanceKm: Double,
     val durationSeconds: Double,

--- a/common/src/main/java/com/ridestr/common/ui/components/HistoryComponents.kt
+++ b/common/src/main/java/com/ridestr/common/ui/components/HistoryComponents.kt
@@ -113,7 +113,9 @@ private fun HistoryEntryCard(
         dateFormat.format(Date(ride.timestamp * 1000))
     }
 
-    val fareDisplay = ride.formatFareDisplay(displayCurrency, btcPriceUsd)
+    val fareDisplay = remember(ride, displayCurrency, btcPriceUsd) {
+        ride.formatFareDisplay(displayCurrency, btcPriceUsd)
+    }
     val isCompleted = ride.status == "completed"
 
     Card(
@@ -180,17 +182,21 @@ private fun HistoryEntryCard(
 
             Spacer(modifier = Modifier.height(12.dp))
 
-            val pickupDisplay = ride.pickupAddress
-                ?: ride.pickupLat?.let { lat ->
-                    ride.pickupLon?.let { lon -> String.format(Locale.US, "%.4f, %.4f", lat, lon) }
-                }
-                ?: "${ride.pickupGeohash.take(4)}..."
+            val pickupDisplay = remember(ride) {
+                ride.pickupAddress
+                    ?: ride.pickupLat?.let { lat ->
+                        ride.pickupLon?.let { lon -> String.format(Locale.US, "%.4f, %.4f", lat, lon) }
+                    }
+                    ?: "${ride.pickupGeohash.take(4)}..."
+            }
 
-            val dropoffDisplay = ride.dropoffAddress
-                ?: ride.dropoffLat?.let { lat ->
-                    ride.dropoffLon?.let { lon -> String.format(Locale.US, "%.4f, %.4f", lat, lon) }
-                }
-                ?: "${ride.dropoffGeohash.take(4)}..."
+            val dropoffDisplay = remember(ride) {
+                ride.dropoffAddress
+                    ?: ride.dropoffLat?.let { lat ->
+                        ride.dropoffLon?.let { lon -> String.format(Locale.US, "%.4f, %.4f", lat, lon) }
+                    }
+                    ?: "${ride.dropoffGeohash.take(4)}..."
+            }
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -332,12 +338,15 @@ private fun HistoryStatsCard(
 
             Spacer(modifier = Modifier.height(12.dp))
 
-            val completedRiderRides = rides.filter { it.role == "rider" && it.status == "completed" }
-            val totalSpentDisplay = when (displayCurrency) {
-                DisplayCurrency.SATS -> "${stats.totalFareSatsPaid} sats"
-                DisplayCurrency.USD -> completedRiderRides.sumFareUsdOrNull(btcPriceUsd)
-                    ?.formatUsd()
-                    ?: "${stats.totalFareSatsPaid} sats"
+            val totalSpentDisplay = remember(rides, stats.totalFareSatsPaid, displayCurrency, btcPriceUsd) {
+                when (displayCurrency) {
+                    DisplayCurrency.SATS -> "${stats.totalFareSatsPaid} sats"
+                    DisplayCurrency.USD -> rides
+                        .filter { it.role == "rider" && it.status == "completed" }
+                        .sumFareUsdOrNull(btcPriceUsd)
+                        ?.formatUsd()
+                        ?: "${stats.totalFareSatsPaid} sats"
+                }
             }
 
             Surface(

--- a/common/src/test/java/com/ridestr/common/fiat/SatsPlaceholderTest.kt
+++ b/common/src/test/java/com/ridestr/common/fiat/SatsPlaceholderTest.kt
@@ -1,0 +1,35 @@
+package com.ridestr.common.fiat
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Pins the SATS-mode placeholder contract (Issue #72): when no BTC price is
+ * available and a caller would otherwise silently fall back to a `$X.XX`
+ * string that looks identical to USD mode, formatters must render the
+ * [SATS_PLACEHOLDER] instead so the currency-toggle UX stays consistent.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class SatsPlaceholderTest {
+
+    @Test
+    fun `null sats yields placeholder not a dollar string`() {
+        val formatted = formatSatsOrPlaceholder(null)
+        assertEquals(SATS_PLACEHOLDER, formatted)
+        assert(!formatted.contains("$")) { "placeholder must not look like USD: '$formatted'" }
+    }
+
+    @Test
+    fun `non-null sats renders with thousands separator and sats suffix`() {
+        assertEquals("12,345 sats", formatSatsOrPlaceholder(12_345L))
+    }
+
+    @Test
+    fun `zero sats still renders the labeled sats string`() {
+        assertEquals("0 sats", formatSatsOrPlaceholder(0L))
+    }
+}

--- a/drivestr/src/main/java/com/drivestr/app/ui/screens/DriverModeScreen.kt
+++ b/drivestr/src/main/java/com/drivestr/app/ui/screens/DriverModeScreen.kt
@@ -517,6 +517,17 @@ fun DriverModeScreen(
             )
         }
 
+        // Per-offer callbacks stabilized so children that `remember`-wrap them
+        // (OfferInbox / RoadflareFollowerList / item children) see the same
+        // lambda identity across recompositions — otherwise the child-side
+        // `remember(offer, onAccept)` would invalidate every frame (see #71).
+        val onAcceptOfferStable = remember(viewModel) { { offer: RideOfferData -> viewModel.acceptOffer(offer) } }
+        val onDeclineOfferStable = remember(viewModel) { { offer: RideOfferData -> viewModel.declineOffer(offer) } }
+        val onAcceptBroadcastStable = remember(viewModel) { { req: BroadcastRideOfferData -> viewModel.acceptBroadcastRequest(req) } }
+        val onDeclineBroadcastStable = remember(viewModel) { { req: BroadcastRideOfferData -> viewModel.declineBroadcastRequest(req) } }
+        val onSetNoMatchWarningStable = remember(viewModel) { { id: String -> viewModel.setNoMatchWarningOffer(id) } }
+        val onDismissNoMatchWarningStable = remember(viewModel) { { viewModel.dismissNoMatchWarning() } }
+
         // Main content based on driver stage
         Crossfade(
             targetState = uiState.stage,
@@ -572,10 +583,10 @@ fun DriverModeScreen(
                         }
                     },
                     onGoOffline = { viewModel.goOffline() },
-                    onAcceptOffer = { viewModel.acceptOffer(it) },
-                    onDeclineOffer = { viewModel.declineOffer(it) },
-                    onSetNoMatchWarning = { viewModel.setNoMatchWarningOffer(it) },
-                    onDismissNoMatchWarning = { viewModel.dismissNoMatchWarning() },
+                    onAcceptOffer = onAcceptOfferStable,
+                    onDeclineOffer = onDeclineOfferStable,
+                    onSetNoMatchWarning = onSetNoMatchWarningStable,
+                    onDismissNoMatchWarning = onDismissNoMatchWarningStable,
                     displayCurrency = settings.displayCurrency,
                     distanceUnit = settings.distanceUnit,
                     roadflarePaymentMethods = settings.roadflarePaymentMethods,
@@ -589,12 +600,12 @@ fun DriverModeScreen(
                     uiState = uiState,
                     onGoOffline = { viewModel.goOffline() },
                     onToggleExpandedSearch = { viewModel.toggleExpandedSearch() },
-                    onAcceptBroadcastRequest = { viewModel.acceptBroadcastRequest(it) },
-                    onDeclineBroadcastRequest = { viewModel.declineBroadcastRequest(it) },
-                    onAcceptOffer = { viewModel.acceptOffer(it) },
-                    onDeclineOffer = { viewModel.declineOffer(it) },
-                    onSetNoMatchWarning = { viewModel.setNoMatchWarningOffer(it) },
-                    onDismissNoMatchWarning = { viewModel.dismissNoMatchWarning() },
+                    onAcceptBroadcastRequest = onAcceptBroadcastStable,
+                    onDeclineBroadcastRequest = onDeclineBroadcastStable,
+                    onAcceptOffer = onAcceptOfferStable,
+                    onDeclineOffer = onDeclineOfferStable,
+                    onSetNoMatchWarning = onSetNoMatchWarningStable,
+                    onDismissNoMatchWarning = onDismissNoMatchWarningStable,
                     displayCurrency = settings.displayCurrency,
                     distanceUnit = settings.distanceUnit,
                     roadflarePaymentMethods = settings.roadflarePaymentMethods,

--- a/drivestr/src/main/java/com/drivestr/app/ui/screens/components/DriverModeScreenComponents.kt
+++ b/drivestr/src/main/java/com/drivestr/app/ui/screens/components/DriverModeScreenComponents.kt
@@ -9,6 +9,8 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -16,12 +18,46 @@ import com.ridestr.common.bitcoin.BitcoinPriceService
 import com.ridestr.common.fiat.formatUsd
 import com.ridestr.common.fiat.usdAmountOrNull
 import com.ridestr.common.nostr.events.BroadcastRideOfferData
+import com.ridestr.common.nostr.events.PaymentMethod
 import com.ridestr.common.nostr.events.RideOfferData
 import com.ridestr.common.routing.RouteResult
 import com.ridestr.common.settings.DisplayCurrency
 import com.ridestr.common.settings.DistanceUnit
 import com.ridestr.common.ui.FareDisplay
 import java.util.Locale
+
+/**
+ * Leaf composable that isolates the 1Hz relative-time ticker from the enclosing card.
+ *
+ * Before Issue #71 the ticker lived inside [RideOfferCard] / [BroadcastRideRequestCard]
+ * and each 1s tick recomposed the whole card — re-running route maths, earnings
+ * calculations, and payment-method lookups for every visible offer. Pulling the
+ * ticker into this leaf means only the `Text` itself recomposes each second; the
+ * surrounding card stays stable.
+ */
+@Composable
+private fun RelativeTimeText(
+    timestampSeconds: Long,
+    style: TextStyle,
+    color: Color,
+    modifier: Modifier = Modifier
+) {
+    var relativeTime by remember(timestampSeconds) {
+        mutableStateOf(formatRelativeTime(timestampSeconds))
+    }
+    LaunchedEffect(timestampSeconds) {
+        while (true) {
+            relativeTime = formatRelativeTime(timestampSeconds)
+            kotlinx.coroutines.delay(1000)
+        }
+    }
+    Text(
+        text = relativeTime,
+        style = style,
+        color = color,
+        modifier = modifier
+    )
+}
 
 private fun formatRelativeTime(timestampSeconds: Long): String {
     val nowSeconds = System.currentTimeMillis() / 1000
@@ -80,8 +116,137 @@ internal fun formatEarnings(
 }
 
 private fun effectiveRoadflareDriverMethods(driverFiatMethods: List<String>): List<String> {
-    val bitcoin = com.ridestr.common.nostr.events.PaymentMethod.BITCOIN.value
+    val bitcoin = PaymentMethod.BITCOIN.value
     return (driverFiatMethods + bitcoin).distinctBy { it.trim().lowercase() }
+}
+
+/**
+ * Intercept accept taps on fiat RoadFlare offers with no common payment method
+ * (Issue #46). Routes to a warning dialog instead of accepting when the driver
+ * can't actually settle in any method the rider prefers.
+ */
+private fun handleOfferAccept(
+    offer: RideOfferData,
+    driverFiatMethods: List<String>,
+    onAcceptOffer: (RideOfferData) -> Unit,
+    onSetNoMatchWarning: (String) -> Unit
+) {
+    val needsWarning = offer.isRoadflare &&
+        offer.paymentMethod != "cashu" &&
+        offer.fiatPaymentMethods.isNotEmpty() &&
+        PaymentMethod.findBestCommonFiatMethod(
+            offer.fiatPaymentMethods,
+            effectiveRoadflareDriverMethods(driverFiatMethods)
+        ) == null
+
+    if (needsWarning) onSetNoMatchWarning(offer.eventId) else onAcceptOffer(offer)
+}
+
+/**
+ * Earnings strings rendered beneath an offer card. Packaged in a single value so
+ * both fields are computed in one [remember] block — the math shares all inputs and
+ * always runs together. See Issue #71: previously these recomputed on every 1Hz
+ * ticker recomposition.
+ */
+private data class EarningsDisplay(val perHour: String?, val perDistance: String?) {
+    companion object {
+        val None = EarningsDisplay(perHour = null, perDistance = null)
+    }
+}
+
+/**
+ * Compute per-hour and per-distance earnings strings from raw offer inputs.
+ *
+ * [pickupDistanceKm] and [pickupDurationMin] are nullable to express "pickup
+ * route not yet calculated". Both must be present to produce a meaningful
+ * total-distance figure (driver only gets paid for ride miles but has to drive
+ * pickup miles too — per-mile earnings must reflect the total).
+ */
+private fun computeEarningsDisplay(
+    fareSats: Double,
+    authoritativeUsdFare: Double?,
+    pickupDistanceKm: Double?,
+    pickupDurationMin: Double?,
+    rideDistanceKm: Double?,
+    rideDurationMin: Double?,
+    displayCurrency: DisplayCurrency,
+    distanceUnit: DistanceUnit,
+    btcPriceUsd: Int?
+): EarningsDisplay {
+    if (pickupDurationMin == null || rideDurationMin == null) return EarningsDisplay.None
+
+    val totalTimeHours = (pickupDurationMin + rideDurationMin) / 60.0
+    val totalDistanceKm = (pickupDistanceKm ?: 0.0) + (rideDistanceKm ?: 0.0)
+    val totalDistanceForEarnings = if (distanceUnit == DistanceUnit.MILES) {
+        totalDistanceKm * 0.621371
+    } else {
+        totalDistanceKm
+    }
+
+    val perHour = if (totalTimeHours > 0) {
+        formatEarnings(
+            satsPerUnit = fareSats / totalTimeHours,
+            displayCurrency = displayCurrency,
+            btcPriceUsd = btcPriceUsd,
+            suffix = "/hr",
+            fiatAmountPerUnitUsd = authoritativeUsdFare?.div(totalTimeHours)
+        )
+    } else null
+
+    val perDistance = if (totalDistanceForEarnings > 0) {
+        val perDistanceUnit = if (distanceUnit == DistanceUnit.MILES) "/mi" else "/km"
+        formatEarnings(
+            satsPerUnit = fareSats / totalDistanceForEarnings,
+            displayCurrency = displayCurrency,
+            btcPriceUsd = btcPriceUsd,
+            suffix = perDistanceUnit,
+            fiatAmountPerUnitUsd = authoritativeUsdFare?.div(totalDistanceForEarnings)
+        )
+    } else null
+
+    return EarningsDisplay(perHour = perHour, perDistance = perDistance)
+}
+
+/**
+ * Pre-computed payment-method match display for a RoadFlare fiat offer. Lets the
+ * card branch on the display variant without re-running `findBestCommonFiatMethod`
+ * (which allocates a fresh list via [effectiveRoadflareDriverMethods] and scans
+ * both sides for a common method) on every recomposition.
+ */
+private sealed class PaymentMatchDisplay {
+    /** Cashu offer, or non-RoadFlare — no match row rendered. */
+    object Hidden : PaymentMatchDisplay()
+
+    /** Driver and rider share at least one fiat method. */
+    data class BestMatch(val methodDisplay: String) : PaymentMatchDisplay()
+
+    /** Rider advertised methods; driver has none in common — block acceptance. */
+    object NoCommon : PaymentMatchDisplay()
+
+    /** Legacy offer without `fiat_payment_methods` — show the single declared method. */
+    data class LegacyMethod(val methodDisplay: String) : PaymentMatchDisplay()
+}
+
+private fun computePaymentMatch(
+    offer: RideOfferData,
+    driverFiatMethods: List<String>
+): PaymentMatchDisplay {
+    val bestMatch = if (offer.fiatPaymentMethods.isNotEmpty()) {
+        PaymentMethod.findBestCommonFiatMethod(
+            offer.fiatPaymentMethods,
+            effectiveRoadflareDriverMethods(driverFiatMethods)
+        )
+    } else null
+
+    return when {
+        bestMatch != null -> PaymentMatchDisplay.BestMatch(
+            methodDisplay = PaymentMethod.fromString(bestMatch)?.displayName ?: bestMatch
+        )
+        offer.fiatPaymentMethods.isNotEmpty() -> PaymentMatchDisplay.NoCommon
+        else -> PaymentMatchDisplay.LegacyMethod(
+            methodDisplay = PaymentMethod.fromString(offer.paymentMethod)?.displayName ?: offer.paymentMethod
+        )
+    }
 }
 
 @Composable
@@ -100,58 +265,55 @@ private fun RideOfferCard(
 ) {
     val btcPrice by priceService.btcPriceUsd.collectAsState()
 
-    // Update relative time every second
-    var relativeTime by remember { mutableStateOf(formatRelativeTime(offer.createdAt)) }
-    LaunchedEffect(offer.createdAt) {
-        while (true) {
-            relativeTime = formatRelativeTime(offer.createdAt)
-            kotlinx.coroutines.delay(1000)
-        }
+    // Route info — cached so we don't re-unbox nullable fields on every recomposition
+    // (the full card still recomposes on btcPrice changes, but not on the 1Hz ticker).
+    val pickupDistanceKm = remember(pickupRoute) { pickupRoute?.distanceKm }
+    val pickupDurationMin = remember(pickupRoute) { pickupRoute?.let { it.durationSeconds / 60.0 } }
+    val rideDistanceKm = remember(rideRoute) { rideRoute?.distanceKm }
+    val rideDurationMin = remember(rideRoute) { rideRoute?.let { it.durationSeconds / 60.0 } }
+    val authoritativeUsdFare = remember(offer.fiatFare) { offer.fiatFare?.usdAmountOrNull() }
+
+    // Earnings math — only recomputes when routes, currency, distance unit, or BTC price change.
+    val earnings = remember(
+        offer.fareEstimate,
+        authoritativeUsdFare,
+        pickupDistanceKm,
+        pickupDurationMin,
+        rideDistanceKm,
+        rideDurationMin,
+        displayCurrency,
+        distanceUnit,
+        btcPrice
+    ) {
+        computeEarningsDisplay(
+            fareSats = offer.fareEstimate,
+            authoritativeUsdFare = authoritativeUsdFare,
+            pickupDistanceKm = pickupDistanceKm,
+            pickupDurationMin = pickupDurationMin,
+            rideDistanceKm = rideDistanceKm,
+            rideDurationMin = rideDurationMin,
+            displayCurrency = displayCurrency,
+            distanceUnit = distanceUnit,
+            btcPriceUsd = btcPrice
+        )
     }
+    val earningsPerHour = earnings.perHour
+    val earningsPerDistance = earnings.perDistance
 
-    // Route info calculations
-    val pickupDistanceKm = pickupRoute?.distanceKm
-    val pickupDurationMin = pickupRoute?.let { it.durationSeconds / 60.0 }
-    val rideDistanceKm = rideRoute?.distanceKm
-    val rideDurationMin = rideRoute?.let { it.durationSeconds / 60.0 }
-
-    // Calculate earnings metrics (only if we have both routes)
-    val earningsPerHour: String?
-    val earningsPerDistance: String?
-    val authoritativeUsdFare = offer.fiatFare?.usdAmountOrNull()
-
-    if (pickupRoute != null && rideRoute != null && pickupDurationMin != null && rideDurationMin != null) {
-        val totalTimeHours = (pickupDurationMin + rideDurationMin) / 60.0
-        val totalDistanceKm = (pickupDistanceKm ?: 0.0) + (rideDistanceKm ?: 0.0)
-        val totalDistanceForEarnings = if (distanceUnit == DistanceUnit.MILES) {
-            totalDistanceKm * 0.621371
+    // Fiat payment-method best match (RoadFlare offers only). Wrapped in remember so the
+    // allocation-heavy list merge + `findBestCommonFiatMethod` scan doesn't re-run each
+    // recomposition — the inputs only change when the offer or driver methods change.
+    val paymentMatch = remember(
+        offer.isRoadflare,
+        offer.paymentMethod,
+        offer.fiatPaymentMethods,
+        driverFiatMethods
+    ) {
+        if (!offer.isRoadflare || offer.paymentMethod == "cashu") {
+            PaymentMatchDisplay.Hidden
         } else {
-            totalDistanceKm
+            computePaymentMatch(offer, driverFiatMethods)
         }
-
-        earningsPerHour = if (totalTimeHours > 0) {
-            formatEarnings(
-                satsPerUnit = offer.fareEstimate / totalTimeHours,
-                displayCurrency = displayCurrency,
-                btcPriceUsd = btcPrice,
-                suffix = "/hr",
-                fiatAmountPerUnitUsd = authoritativeUsdFare?.div(totalTimeHours)
-            )
-        } else null
-
-        earningsPerDistance = if (totalDistanceForEarnings > 0) {
-            val perDistanceUnit = if (distanceUnit == DistanceUnit.MILES) "/mi" else "/km"
-            formatEarnings(
-                satsPerUnit = offer.fareEstimate / totalDistanceForEarnings,
-                displayCurrency = displayCurrency,
-                btcPriceUsd = btcPrice,
-                suffix = perDistanceUnit,
-                fiatAmountPerUnitUsd = authoritativeUsdFare?.div(totalDistanceForEarnings)
-            )
-        } else null
-    } else {
-        earningsPerHour = null
-        earningsPerDistance = null
     }
 
     Card(modifier = Modifier.fillMaxWidth()) {
@@ -186,40 +348,27 @@ private fun RideOfferCard(
                         color = if (offer.isRoadflare) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.primary
                     )
                     // Show fiat payment match status for RoadFlare offers (Issue #46)
-                    if (offer.isRoadflare && offer.paymentMethod != "cashu") {
-                        val bestMatch = if (offer.fiatPaymentMethods.isNotEmpty()) {
-                            com.ridestr.common.nostr.events.PaymentMethod.findBestCommonFiatMethod(
-                                offer.fiatPaymentMethods,
-                                effectiveRoadflareDriverMethods(driverFiatMethods)
-                            )
-                        } else null
-                        val methodDisplay = com.ridestr.common.nostr.events.PaymentMethod.fromString(offer.paymentMethod)?.displayName ?: offer.paymentMethod
-
-                        if (bestMatch != null) {
-                            val matchDisplay = com.ridestr.common.nostr.events.PaymentMethod.fromString(bestMatch)?.displayName ?: bestMatch
-                            Text(
-                                text = "Pay via: $matchDisplay",
-                                style = MaterialTheme.typography.labelSmall,
-                                color = androidx.compose.ui.graphics.Color(0xFF2E7D32) // Green
-                            )
-                        } else if (offer.fiatPaymentMethods.isNotEmpty()) {
-                            Text(
-                                text = "No Common Payment Method",
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.error
-                            )
-                        } else {
-                            // Legacy offer without fiat_payment_methods field
-                            Text(
-                                text = "Payment: $methodDisplay",
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.tertiary
-                            )
-                        }
+                    when (paymentMatch) {
+                        PaymentMatchDisplay.Hidden -> Unit
+                        is PaymentMatchDisplay.BestMatch -> Text(
+                            text = "Pay via: ${paymentMatch.methodDisplay}",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = Color(0xFF2E7D32) // Green
+                        )
+                        PaymentMatchDisplay.NoCommon -> Text(
+                            text = "No Common Payment Method",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                        is PaymentMatchDisplay.LegacyMethod -> Text(
+                            text = "Payment: ${paymentMatch.methodDisplay}",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.tertiary
+                        )
                     }
                 }
-                Text(
-                    text = relativeTime,
+                RelativeTimeText(
+                    timestampSeconds = offer.createdAt,
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -367,71 +516,50 @@ private fun BroadcastRideRequestCard(
 ) {
     val btcPrice by priceService.btcPriceUsd.collectAsState()
 
-    // Update relative time every second
-    var relativeTime by remember { mutableStateOf(formatRelativeTime(request.createdAt)) }
-    LaunchedEffect(request.createdAt) {
-        while (true) {
-            relativeTime = formatRelativeTime(request.createdAt)
-            kotlinx.coroutines.delay(1000)
-        }
-    }
-
-    // Distance conversion (km to miles if needed)
     val rideDistanceKm = request.routeDistanceKm
     val rideDurationMin = request.routeDurationMin
-
-    // Format ride distance based on user preference
-    val rideDistanceStr = formatDistance(rideDistanceKm, distanceUnit)
-
-    // Pickup route info (only available if calculated)
-    val pickupDistanceKm = pickupRoute?.distanceKm
-    val pickupDurationMin = pickupRoute?.let { it.durationSeconds / 60.0 }
-    val pickupDistanceStr = pickupDistanceKm?.let { formatDistance(it, distanceUnit) }
-
-    // Calculate earnings metrics ONLY if we have pickup route data
-    // Without pickup time, $/hr would be misleadingly high
-    val earningsPerHour: String?
-    val earningsPerDistance: String?
-    val authoritativeUsdFare = request.fiatFare?.usdAmountOrNull()
-
-    if (pickupRoute != null && pickupDurationMin != null && pickupDistanceKm != null) {
-        // Total time = pickup time + ride time (in hours)
-        val totalTimeHours = (pickupDurationMin + rideDurationMin) / 60.0
-
-        // Total distance = pickup + ride (driver has to drive both, only gets paid for ride)
-        // This gives accurate $/mile for total miles driven
-        val totalDistanceKm = pickupDistanceKm + rideDistanceKm
-        val totalDistanceForEarnings = if (distanceUnit == DistanceUnit.MILES) {
-            totalDistanceKm * 0.621371
-        } else {
-            totalDistanceKm
-        }
-
-        earningsPerHour = if (totalTimeHours > 0) {
-            formatEarnings(
-                satsPerUnit = request.fareEstimate / totalTimeHours,
-                displayCurrency = displayCurrency,
-                btcPriceUsd = btcPrice,
-                suffix = "/hr",
-                fiatAmountPerUnitUsd = authoritativeUsdFare?.div(totalTimeHours)
-            )
-        } else null
-
-        earningsPerDistance = if (totalDistanceForEarnings > 0) {
-            val perDistanceUnit = if (distanceUnit == DistanceUnit.MILES) "/mi" else "/km"
-            formatEarnings(
-                satsPerUnit = request.fareEstimate / totalDistanceForEarnings,
-                displayCurrency = displayCurrency,
-                btcPriceUsd = btcPrice,
-                suffix = perDistanceUnit,
-                fiatAmountPerUnitUsd = authoritativeUsdFare?.div(totalDistanceForEarnings)
-            )
-        } else null
-    } else {
-        // Don't show earnings without pickup route - they'd be misleading
-        earningsPerHour = null
-        earningsPerDistance = null
+    val rideDistanceStr = remember(rideDistanceKm, distanceUnit) {
+        formatDistance(rideDistanceKm, distanceUnit)
     }
+
+    val pickupDistanceKm = remember(pickupRoute) { pickupRoute?.distanceKm }
+    val pickupDurationMin = remember(pickupRoute) { pickupRoute?.let { it.durationSeconds / 60.0 } }
+    val pickupDistanceStr = remember(pickupDistanceKm, distanceUnit) {
+        pickupDistanceKm?.let { formatDistance(it, distanceUnit) }
+    }
+    val authoritativeUsdFare = remember(request.fiatFare) { request.fiatFare?.usdAmountOrNull() }
+
+    // Earnings: only meaningful when we have the pickup route (without pickup time,
+    // $/hr would be misleadingly high). Remember so the math doesn't run per-tick.
+    val earnings = remember(
+        request.fareEstimate,
+        authoritativeUsdFare,
+        pickupDistanceKm,
+        pickupDurationMin,
+        rideDistanceKm,
+        rideDurationMin,
+        displayCurrency,
+        distanceUnit,
+        btcPrice
+    ) {
+        if (pickupDistanceKm == null || pickupDurationMin == null) {
+            EarningsDisplay.None
+        } else {
+            computeEarningsDisplay(
+                fareSats = request.fareEstimate,
+                authoritativeUsdFare = authoritativeUsdFare,
+                pickupDistanceKm = pickupDistanceKm,
+                pickupDurationMin = pickupDurationMin,
+                rideDistanceKm = rideDistanceKm,
+                rideDurationMin = rideDurationMin,
+                displayCurrency = displayCurrency,
+                distanceUnit = distanceUnit,
+                btcPriceUsd = btcPrice
+            )
+        }
+    }
+    val earningsPerHour = earnings.perHour
+    val earningsPerDistance = earnings.perDistance
 
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -472,8 +600,8 @@ private fun BroadcastRideRequestCard(
                         )
                     }
                 }
-                Text(
-                    text = relativeTime,
+                RelativeTimeText(
+                    timestampSeconds = request.createdAt,
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -771,33 +899,35 @@ fun RoadflareFollowerList(
             style = MaterialTheme.typography.titleMedium,
             modifier = Modifier.padding(top = 8.dp)
         )
+        // N is small (personal follower network) so a non-lazy Column is fine — the
+        // per-card ticker has been hoisted to [RelativeTimeText] so the cost no longer
+        // compounds with list length.
         pendingOffers.forEach { offer ->
-            RideOfferCard(
-                offer = offer,
-                pickupRoute = directOfferPickupRoutes[offer.eventId],
-                rideRoute = directOfferRideRoutes[offer.eventId],
-                isProcessing = isProcessingOffer,
-                onAccept = {
-                    // Intercept fiat offers with no common method (Issue #46)
-                    if (offer.isRoadflare && offer.paymentMethod != "cashu" &&
-                        offer.fiatPaymentMethods.isNotEmpty() &&
-                        com.ridestr.common.nostr.events.PaymentMethod.findBestCommonFiatMethod(
-                            offer.fiatPaymentMethods,
-                            effectiveRoadflareDriverMethods(driverFiatMethods)
-                        ) == null
-                    ) {
-                        onSetNoMatchWarning(offer.eventId)
-                    } else {
-                        onAcceptOffer(offer)
-                    }
-                },
-                onDecline = { onDeclineOffer(offer) },
-                displayCurrency = displayCurrency,
-                distanceUnit = distanceUnit,
-                onToggleCurrency = onToggleCurrency,
-                priceService = priceService,
-                driverFiatMethods = driverFiatMethods
-            )
+            key(offer.eventId) {
+                val pickupRoute = directOfferPickupRoutes[offer.eventId]
+                val rideRoute = directOfferRideRoutes[offer.eventId]
+                val onAccept = remember(
+                    offer, driverFiatMethods, onAcceptOffer, onSetNoMatchWarning
+                ) {
+                    { handleOfferAccept(offer, driverFiatMethods, onAcceptOffer, onSetNoMatchWarning) }
+                }
+                val onDecline = remember(offer, onDeclineOffer) {
+                    { onDeclineOffer(offer) }
+                }
+                RideOfferCard(
+                    offer = offer,
+                    pickupRoute = pickupRoute,
+                    rideRoute = rideRoute,
+                    isProcessing = isProcessingOffer,
+                    onAccept = onAccept,
+                    onDecline = onDecline,
+                    displayCurrency = displayCurrency,
+                    distanceUnit = distanceUnit,
+                    onToggleCurrency = onToggleCurrency,
+                    priceService = priceService,
+                    driverFiatMethods = driverFiatMethods
+                )
+            }
         }
     } else {
         Card(
@@ -921,14 +1051,24 @@ fun OfferInbox(
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             // Show broadcast requests first (sorted by fare, highest first)
-            // Using freshBroadcastRequests which filters out stale requests
-            items(freshBroadcastRequests) { request ->
+            // Using freshBroadcastRequests which filters out stale requests.
+            items(
+                items = freshBroadcastRequests,
+                key = { it.eventId }
+            ) { request ->
+                val pickupRoute = pickupRoutes[request.eventId]
+                val onAccept = remember(request, onAcceptBroadcastRequest) {
+                    { onAcceptBroadcastRequest(request) }
+                }
+                val onDecline = remember(request, onDeclineBroadcastRequest) {
+                    { onDeclineBroadcastRequest(request) }
+                }
                 BroadcastRideRequestCard(
                     request = request,
-                    pickupRoute = pickupRoutes[request.eventId],
+                    pickupRoute = pickupRoute,
                     isProcessing = isProcessingOffer,
-                    onAccept = { onAcceptBroadcastRequest(request) },
-                    onDecline = { onDeclineBroadcastRequest(request) },
+                    onAccept = onAccept,
+                    onDecline = onDecline,
                     displayCurrency = displayCurrency,
                     distanceUnit = distanceUnit,
                     onToggleCurrency = onToggleCurrency,
@@ -946,27 +1086,27 @@ fun OfferInbox(
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
-                items(pendingOffers) { offer ->
+                items(
+                    items = pendingOffers,
+                    key = { it.eventId }
+                ) { offer ->
+                    val pickupRoute = directOfferPickupRoutes[offer.eventId]
+                    val rideRoute = directOfferRideRoutes[offer.eventId]
+                    val onAccept = remember(
+                        offer, driverFiatMethods, onAcceptOffer, onSetNoMatchWarning
+                    ) {
+                        { handleOfferAccept(offer, driverFiatMethods, onAcceptOffer, onSetNoMatchWarning) }
+                    }
+                    val onDecline = remember(offer, onDeclineOffer) {
+                        { onDeclineOffer(offer) }
+                    }
                     RideOfferCard(
                         offer = offer,
-                        pickupRoute = directOfferPickupRoutes[offer.eventId],
-                        rideRoute = directOfferRideRoutes[offer.eventId],
+                        pickupRoute = pickupRoute,
+                        rideRoute = rideRoute,
                         isProcessing = isProcessingOffer,
-                        onAccept = {
-                            // Intercept fiat offers with no common method (Issue #46)
-                            if (offer.isRoadflare && offer.paymentMethod != "cashu" &&
-                                offer.fiatPaymentMethods.isNotEmpty() &&
-                                com.ridestr.common.nostr.events.PaymentMethod.findBestCommonFiatMethod(
-                                    offer.fiatPaymentMethods,
-                                    effectiveRoadflareDriverMethods(driverFiatMethods)
-                                ) == null
-                            ) {
-                                onSetNoMatchWarning(offer.eventId)
-                            } else {
-                                onAcceptOffer(offer)
-                            }
-                        },
-                        onDecline = { onDeclineOffer(offer) },
+                        onAccept = onAccept,
+                        onDecline = onDecline,
                         displayCurrency = displayCurrency,
                         distanceUnit = distanceUnit,
                         onToggleCurrency = onToggleCurrency,

--- a/rider-app/src/main/java/com/ridestr/rider/ui/screens/RiderModeScreen.kt
+++ b/rider-app/src/main/java/com/ridestr/rider/ui/screens/RiderModeScreen.kt
@@ -401,6 +401,7 @@ fun RiderModeScreen(
         showDriverUnavailable = uiState.rideSession.showDriverUnavailableDialog,
         showEscrowFailed = uiState.rideSession.showEscrowFailedDialog,
         escrowFailedMessage = uiState.rideSession.escrowFailedMessage,
+        paymentPath = uiState.rideSession.paymentPath,
         onDismissCancelWarning = { viewModel.dismissCancelWarning() },
         onConfirmCancelWarning = { viewModel.confirmCancelAfterWarning() },
         onDismissDriverUnavailable = { viewModel.dismissDriverUnavailable() },

--- a/rider-app/src/main/java/com/ridestr/rider/ui/screens/components/RiderModeScreenComponents.kt
+++ b/rider-app/src/main/java/com/ridestr/rider/ui/screens/components/RiderModeScreenComponents.kt
@@ -506,18 +506,17 @@ internal fun CancelDialogStack(
         // Fiat/RoadFlare (and NO_PAYMENT) rides don't — phrase the warning in
         // terms of "driver has been notified" instead of payment claiming. See #59.
         val hasEscrow = paymentPath == PaymentPath.SAME_MINT || paymentPath == PaymentPath.CROSS_MINT
-        val (title, body, footer) = if (hasEscrow) {
-            Triple(
-                "Payment Already Sent",
-                "Your payment has already been authorized to the driver. If you cancel now, the driver can still claim the fare.",
-                "Cancelling does not guarantee a refund."
-            )
+        val title: String
+        val body: String
+        val footer: String?
+        if (hasEscrow) {
+            title = "Payment Already Sent"
+            body = "Your payment has already been authorized to the driver. If you cancel now, the driver can still claim the fare."
+            footer = "Cancelling does not guarantee a refund."
         } else {
-            Triple(
-                "Cancel This Ride?",
-                "Your driver has been notified and may already be on the way. Cancelling now may inconvenience them.",
-                null
-            )
+            title = "Cancel This Ride?"
+            body = "Your driver has been notified and may already be on the way. Cancelling now may inconvenience them."
+            footer = null
         }
 
         AlertDialog(

--- a/rider-app/src/main/java/com/ridestr/rider/ui/screens/components/RiderModeScreenComponents.kt
+++ b/rider-app/src/main/java/com/ridestr/rider/ui/screens/components/RiderModeScreenComponents.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.ridestr.common.bitcoin.BitcoinPriceService
 import com.ridestr.common.nostr.events.DriverAvailabilityData
+import com.ridestr.common.nostr.events.PaymentPath
 import com.ridestr.common.nostr.events.UserProfile
 import com.ridestr.common.settings.DisplayCurrency
 import com.ridestr.common.ui.ActiveRideCard
@@ -492,6 +493,7 @@ internal fun CancelDialogStack(
     showDriverUnavailable: Boolean,
     showEscrowFailed: Boolean,
     escrowFailedMessage: String?,
+    paymentPath: PaymentPath,
     onDismissCancelWarning: () -> Unit,
     onConfirmCancelWarning: () -> Unit,
     onDismissDriverUnavailable: () -> Unit,
@@ -500,6 +502,24 @@ internal fun CancelDialogStack(
 ) {
     // Cancel warning dialog (shown when cancelling after PIN verification)
     if (showCancelWarning) {
+        // Only Cashu HTLC rides have an escrow the driver can claim post-cancel.
+        // Fiat/RoadFlare (and NO_PAYMENT) rides don't — phrase the warning in
+        // terms of "driver has been notified" instead of payment claiming. See #59.
+        val hasEscrow = paymentPath == PaymentPath.SAME_MINT || paymentPath == PaymentPath.CROSS_MINT
+        val (title, body, footer) = if (hasEscrow) {
+            Triple(
+                "Payment Already Sent",
+                "Your payment has already been authorized to the driver. If you cancel now, the driver can still claim the fare.",
+                "Cancelling does not guarantee a refund."
+            )
+        } else {
+            Triple(
+                "Cancel This Ride?",
+                "Your driver has been notified and may already be on the way. Cancelling now may inconvenience them.",
+                null
+            )
+        }
+
         AlertDialog(
             onDismissRequest = onDismissCancelWarning,
             icon = {
@@ -509,19 +529,19 @@ internal fun CancelDialogStack(
                     tint = MaterialTheme.colorScheme.error
                 )
             },
-            title = { Text("Payment Already Sent") },
+            title = { Text(title) },
             text = {
                 Column {
-                    Text(
-                        "Your payment has already been authorized to the driver. If you cancel now, the driver can still claim the fare."
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Text(
-                        "Cancelling does not guarantee a refund.",
-                        style = MaterialTheme.typography.bodySmall,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.error
-                    )
+                    Text(body)
+                    footer?.let {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            it,
+                            style = MaterialTheme.typography.bodySmall,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                    }
                 }
             },
             confirmButton = {

--- a/roadflare-rider/src/main/java/com/roadflare/rider/ui/screens/DriverSelectionScreen.kt
+++ b/roadflare-rider/src/main/java/com/roadflare/rider/ui/screens/DriverSelectionScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.unit.dp
 import androidx.annotation.VisibleForTesting
 import com.ridestr.common.bitcoin.BitcoinPriceService
 import com.ridestr.common.data.CachedDriverLocation
+import com.ridestr.common.fiat.formatSatsOrPlaceholder
 import com.ridestr.common.nostr.events.AdminConfig
 import com.ridestr.common.nostr.events.FollowedDriver
 import com.ridestr.common.nostr.events.Location
@@ -300,11 +301,7 @@ private fun formatFareUsd(
 ): String {
     return when (displayCurrency) {
         DisplayCurrency.USD -> "$${String.format("%.2f", fareUsd)}"
-        DisplayCurrency.SATS -> {
-            val sats = priceService.usdToSats(fareUsd)
-            if (sats != null) "${String.format("%,d", sats)} sats"
-            else "$${String.format("%.2f", fareUsd)}"
-        }
+        DisplayCurrency.SATS -> formatSatsOrPlaceholder(priceService.usdToSats(fareUsd))
     }
 }
 

--- a/roadflare-rider/src/main/java/com/roadflare/rider/ui/screens/components/DriverNetworkComponents.kt
+++ b/roadflare-rider/src/main/java/com/roadflare/rider/ui/screens/components/DriverNetworkComponents.kt
@@ -179,12 +179,14 @@ private fun DriverCard(
     val dateFormat = remember { SimpleDateFormat("MMM d, yyyy", Locale.getDefault()) }
     val displayName = driverName ?: driver.pubkey.take(8) + "..."
 
-    val distanceMiles = if (riderLocation != null && locationState != null &&
-        locationState.status == RoadflareLocationEvent.Status.ONLINE) {
-        val driverLoc = Location(locationState.lat, locationState.lon)
-        val distanceKm = riderLocation.distanceToKm(driverLoc)
-        distanceKm * 0.621371
-    } else null
+    val distanceMiles = remember(riderLocation, locationState) {
+        if (riderLocation != null && locationState != null &&
+            locationState.status == RoadflareLocationEvent.Status.ONLINE) {
+            val driverLoc = Location(locationState.lat, locationState.lon)
+            val distanceKm = riderLocation.distanceToKm(driverLoc)
+            distanceKm * 0.621371
+        } else null
+    }
 
     Card(
         onClick = onClick,

--- a/roadflare-rider/src/main/java/com/roadflare/rider/ui/screens/components/RideTabComponents.kt
+++ b/roadflare-rider/src/main/java/com/roadflare/rider/ui/screens/components/RideTabComponents.kt
@@ -24,6 +24,7 @@ import androidx.core.content.ContextCompat
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
 import com.ridestr.common.bitcoin.BitcoinPriceService
+import com.ridestr.common.fiat.formatSatsOrPlaceholder
 import com.ridestr.common.fiat.formatUsd
 import com.ridestr.common.settings.DisplayCurrency
 import com.ridestr.common.ui.FavoritesSection
@@ -36,7 +37,6 @@ import com.roadflare.rider.viewmodels.RideSession
 import com.roadflare.rider.viewmodels.RiderViewModel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
-import java.util.Locale
 
 @Composable
 fun formatFareAmount(
@@ -48,11 +48,9 @@ fun formatFareAmount(
     val btcPrice by priceService.btcPriceUsd.collectAsState()
     return when (displayCurrency) {
         DisplayCurrency.USD -> fareUsd.formatUsd()
-        DisplayCurrency.SATS -> {
-            val sats = btcPrice?.takeIf { it > 0 }?.let { priceService.usdToSats(fareUsd) }
-            if (sats != null) String.format(Locale.US, "%,d sats", sats)
-            else fareUsd.formatUsd()
-        }
+        DisplayCurrency.SATS -> formatSatsOrPlaceholder(
+            btcPrice?.takeIf { it > 0 }?.let { priceService.usdToSats(fareUsd) }
+        )
     }
 }
 


### PR DESCRIPTION
Housekeeping + three deferred P1 fixes from the #65/#66/#67 refactor arc. Split into focused commits for easier review.

## Scope

### Code/docs
- **c00c3a1** `docs: reflect post-refactor coordinator + screen-component architecture` — `.claude/CLAUDE.md` updated to reflect the four refactor PRs that landed today (#70, #69, #68, #73). Adds the six new `:common/coordinator/` files to the Quick Implementation Status table, catalogs the per-module `components/` packages in Key Files Reference, and flags coordinators as synthetic hotspots requiring extra care on first bug fixes.
- **(no commit)** Untracked stale rider-app copies deleted from the main-repo checkout: `rider-app/src/main/java/com/ridestr/rider/viewmodels/AvailabilityMonitorPolicy.kt` and its test. PR #70 moved the canonical copy to `:common/coordinator/`; the stale copies were untracked local files flagged in the 2026-04-18 triage. Byte-diffed first — only delta is the expected API migration (`RideStage` → `isWaitingForAcceptance: Boolean`, dropped `SHOW_UNAVAILABLE` variant). No commit needed since they were never tracked in git.

### P1 fixes
- **40a2e8b** `fix: show placeholder in SATS mode when BTC price is unavailable (#72)` — Adds `formatSatsOrPlaceholder` helper in `:common/fiat/FiatFareFormatting`. Applied to `formatFareAmount` (RideTabComponents) + `formatFareUsd` (DriverSelectionScreen), both of which previously fell back silently to `$X.XX` USD when `BitcoinPriceService` hadn't populated a price. Verified that `HistoryStatsCard.totalSpentDisplay` and `RideHistoryEntry.formatFareDisplay` do NOT have this bug (their SATS branch reads `fareSats` directly). Unit test pins the contract. Closes #72.
- **3c0a63e** `perf: reduce recomposition cost in DriverMode offer cards (#71)` — Five-part fix:
  1. `RelativeTimeText` leaf composable isolates the 1Hz ticker from card bodies. Route math, earnings, and `findBestCommonFiatMethod` no longer re-run per second.
  2. Derived values (`pickupDistanceKm`, `pickupDurationMin`, earnings strings, payment-match state) wrapped in keyed `remember` blocks. Earnings logic factored into `EarningsDisplay` + `computeEarningsDisplay`; payment-match into a `PaymentMatchDisplay` sealed class.
  3. `items { }` lambdas hoisted via `remember(offer, callback) { ... }`; `items(key = { it.eventId })` added so LazyList stays aligned.
  4. `RideOfferData`, `BroadcastRideOfferData`, `FiatFare`, `RouteResult`, `FollowedDriver` annotated `@Immutable` (pure value types whose `List<T>` fields cause default-unstable inference).
  5. Same `remember(deps)` pattern applied to `HistoryEntryCard.fareDisplay` / `pickupDisplay` / `dropoffDisplay`, `HistoryStatsCard.totalSpentDisplay`, and `DriverCard.distanceMiles`.

  **Not addressed in this PR:** `Map<String, RouteResult>` / `List<T>` params at the `OfferInbox` / `RoadflareFollowerList` boundary remain intrinsically unstable. Fixing that would require adding `kotlinx.collections.immutable` (new cross-cutting dep) or wrapper `@Immutable` classes for every collection param — filed as [follow-up observation](#follow-up-observations) below. Closes #71.
- **035c51c** `fix: contextual cancel-warning text for fiat/RoadFlare rides (#59)` — `CancelDialogStack` now takes a `PaymentPath` parameter. Cashu HTLC rides (SAME_MINT / CROSS_MINT) keep the existing "driver can still claim the fare / no refund guaranteed" text. Fiat / NO_PAYMENT rides get new text: "Cancel This Ride? / Your driver has been notified and may already be on the way." Trigger condition (`preimageShared || pinVerified`) unchanged — `pinVerified` still surfaces the dialog for fiat rides, just with honest language. Closes #59.

## Follow-up observations

None filed as GitHub issues yet — noting here so they're not lost:

- **Map/List collection stability** at component boundaries (`OfferInbox`, `RoadflareFollowerList`, `FollowedDriverList`). Options: add `kotlinx.collections.immutable` dependency, or define `@Immutable` wrapper data classes. Gate on whether the Compose profiler shows measurable cost from those parents' recompositions after this PR lands — if the leaf ticker + inner `remember` blocks are the dominant cost, the collection-stability work may not be needed.

## Closes
- Closes #59
- Closes #71
- Closes #72

## Test plan
- [x] `./gradlew :common:testDebugUnitTest` passes (adds `SatsPlaceholderTest`)
- [x] `./gradlew :rider-app:assembleDebug :drivestr:assembleDebug :roadflare-rider:assembleDebug` — all three apps assemble clean
- [ ] Manual: SATS-mode fare surfaces show `— sats` placeholder on a cold start (before BTC price fetch), not a `$X.XX` string
- [ ] Manual: Cancel a Cashu ride mid-flight after PIN → "Payment Already Sent" dialog with refund-guarantee language
- [ ] Manual: Cancel a fiat/RoadFlare ride mid-flight after PIN → "Cancel This Ride?" dialog without claim language
- [ ] Manual: Offer inbox with 5+ broadcast requests visible → ticker updates per second without the full card subtree recomposing (inspect via Layout Inspector / Compose recomposition counts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)