### PR TITLE
fix(drivestr): treat Kind 3187 as delivery-retry, never rotate

### DIFF
--- a/common/src/main/java/com/ridestr/common/nostr/events/DriverRoadflareStateEvent.kt
+++ b/common/src/main/java/com/ridestr/common/nostr/events/DriverRoadflareStateEvent.kt
@@ -72,9 +72,14 @@ object DriverRoadflareStateEvent {
             return null
         }
 
-        // Include key_version and key_updated_at in public tags for quick staleness check
+        // Include key_version and key_updated_at in public tags for quick staleness check.
+        // When keyUpdatedAt is null (e.g., a driver who generated a key via OnboardingViewModel
+        // but hasn't approved a follower yet) emit "0", matching key_version's null treatment.
+        // A wall-clock fallback here would silently advance the public tag — riders would see
+        // currentKeyUpdatedAt > storedKeyUpdatedAt and flap into stale-key flagging until the
+        // next real publish. "0 > anything" is always false, so no false-stale.
         val keyVersion = state.roadflareKey?.version?.toString() ?: "0"
-        val keyUpdatedAt = state.keyUpdatedAt?.toString() ?: (System.currentTimeMillis() / 1000).toString()
+        val keyUpdatedAt = state.keyUpdatedAt?.toString() ?: "0"
 
         val tags = arrayOf(
             arrayOf("d", D_TAG),

--- a/common/src/main/java/com/ridestr/common/roadflare/FollowNotificationResult.kt
+++ b/common/src/main/java/com/ridestr/common/roadflare/FollowNotificationResult.kt
@@ -30,11 +30,16 @@ sealed class FollowNotificationResult {
     object AlreadyPending : FollowNotificationResult()
 
     /**
-     * Rider was on the muted list. Mute was removed and the current Kind 3186
-     * key share was re-delivered. The shared keyUpdatedAt is unchanged, so
-     * other followers' stored keys remain valid.
+     * Rider is on the muted list. No-op — the driver's explicit "Remove"
+     * decision is preserved.
+     *
+     * Auto-unmuting on Kind 3187 would silently bypass driver consent and
+     * conflict with the cross-device sync invariant in
+     * `RoadflareDriverCoordinator.mergeMutedLists` ("once muted, always muted —
+     * auto-unmute via sync is intentionally blocked"). To restore a removed
+     * rider the driver re-approves them through the RoadFlare tab.
      */
-    object UnmutedAndKeyResent : FollowNotificationResult()
+    object AlreadyMuted : FollowNotificationResult()
 
     /**
      * Rider was already approved. The current Kind 3186 key share was

--- a/common/src/main/java/com/ridestr/common/roadflare/FollowNotificationResult.kt
+++ b/common/src/main/java/com/ridestr/common/roadflare/FollowNotificationResult.kt
@@ -1,0 +1,53 @@
+package com.ridestr.common.roadflare
+
+/**
+ * Result of [RoadflareKeyManager.handleFollowNotification].
+ *
+ * Kind 3187 follow notifications carry no semantics beyond "rider sent the
+ * driver a follow signal" — they may be a first follow, a re-add after fresh
+ * install, or a delivery-retry when the rider's local backup of the driver's
+ * key share is unavailable. The driver-side handler interprets the rider's
+ * current state in the followers list to decide whether to add as pending,
+ * unmute, or simply re-deliver the existing key.
+ *
+ * Variants are returned to the caller so the UI layer can decide whether
+ * to surface an OS notification (genuinely new follows only) or remain
+ * silent (re-deliveries).
+ */
+sealed class FollowNotificationResult {
+
+    /**
+     * Rider was not in the followers list — added as a pending follower.
+     * Driver must approve via the UI before any Kind 3186 key share is sent.
+     * The call site should surface an OS notification so the driver knows.
+     */
+    object AddedAsPending : FollowNotificationResult()
+
+    /**
+     * Rider is already in the followers list as pending (driver hasn't
+     * approved yet). No-op — driver still owes an approval via UI.
+     */
+    object AlreadyPending : FollowNotificationResult()
+
+    /**
+     * Rider was on the muted list. Mute was removed and the current Kind 3186
+     * key share was re-delivered. The shared keyUpdatedAt is unchanged, so
+     * other followers' stored keys remain valid.
+     */
+    object UnmutedAndKeyResent : FollowNotificationResult()
+
+    /**
+     * Rider was already approved. The current Kind 3186 key share was
+     * re-delivered to recover from a transient delivery failure on the rider
+     * side. No state change — the keyUpdatedAt and Kind 30012 metadata are
+     * untouched.
+     */
+    object KeyResent : FollowNotificationResult()
+
+    /**
+     * Could not complete the requested action.
+     *
+     * @property reason Short human-readable description for logging.
+     */
+    data class Failed(val reason: String) : FollowNotificationResult()
+}

--- a/common/src/main/java/com/ridestr/common/roadflare/FollowNotificationResult.kt
+++ b/common/src/main/java/com/ridestr/common/roadflare/FollowNotificationResult.kt
@@ -8,7 +8,7 @@ package com.ridestr.common.roadflare
  * install, or a delivery-retry when the rider's local backup of the driver's
  * key share is unavailable. The driver-side handler interprets the rider's
  * current state in the followers list to decide whether to add as pending,
- * unmute, or simply re-deliver the existing key.
+ * re-deliver the existing key to an approved follower, or no-op.
  *
  * Variants are returned to the caller so the UI layer can decide whether
  * to surface an OS notification (genuinely new follows only) or remain

--- a/common/src/main/java/com/ridestr/common/roadflare/RoadflareKeyManager.kt
+++ b/common/src/main/java/com/ridestr/common/roadflare/RoadflareKeyManager.kt
@@ -253,20 +253,35 @@ class RoadflareKeyManager(
      *
      * Muted riders are left alone: the driver's "Remove" decision is preserved
      * (matches the cross-device sync invariant in
-     * `RoadflareDriverCoordinator.mergeMutedLists`).
+     * `RoadflareDriverCoordinator.mergeMutedLists`). The mute check runs before
+     * the existence check so that a muted entry without a corresponding
+     * `followers` record (possible after cross-device sync filters out a
+     * follower whose Kind 30011 stopped listing the driver) is not bypassed.
      *
      * @param signer The driver's identity signer (for publishing Kind 3186).
      * @param followerPubkey The rider's pubkey from the Kind 3187 event.
      * @param riderName The rider's display name from the notification body.
-     * @return The action taken; the call site uses this to decide whether to
-     *   surface an OS notification (only for [FollowNotificationResult.AddedAsPending])
+     * @return The action taken. The call site uses this to decide whether to
+     *   surface an OS notification (only [FollowNotificationResult.AddedAsPending])
      *   and whether to refresh profile backups.
+     *   [FollowNotificationResult.AlreadyPending] covers two situations: the
+     *   rider was already pending before this call, OR a concurrent path won
+     *   the add race between the existence check and [addPendingFollower].
      */
     suspend fun handleFollowNotification(
         signer: NostrSigner,
         followerPubkey: String,
         riderName: String
     ): FollowNotificationResult {
+        if (repository.isMuted(followerPubkey)) {
+            // Muted re-add — preserve the driver's "Remove" decision.
+            // Auto-unmute would conflict with mergeMutedLists' "once muted, always
+            // muted" cross-device invariant and silently bypass driver consent.
+            // Checked first so a stale muted entry without a `followers` record
+            // (e.g., after cross-device sync) cannot be bypassed.
+            return FollowNotificationResult.AlreadyMuted
+        }
+
         val existing = repository.state.value?.followers?.find { it.pubkey == followerPubkey }
 
         if (existing == null) {
@@ -279,13 +294,6 @@ class RoadflareKeyManager(
                 // Race: another path added them between our state read and add. Treat as pending.
                 FollowNotificationResult.AlreadyPending
             }
-        }
-
-        if (repository.isMuted(followerPubkey)) {
-            // Muted re-add — preserve the driver's "Remove" decision.
-            // Auto-unmute would conflict with mergeMutedLists' "once muted, always
-            // muted" cross-device invariant and silently bypass driver consent.
-            return FollowNotificationResult.AlreadyMuted
         }
 
         if (existing.approved) {
@@ -305,7 +313,15 @@ class RoadflareKeyManager(
 
     /**
      * Re-send the current Kind 3186 key share to a specific follower.
-     * Uses the existing keyUpdatedAt — does NOT advance it.
+     * Uses the existing [DriverRoadflareRepository.getKeyUpdatedAt]; never
+     * advances it.
+     *
+     * If [DriverRoadflareRepository.getKeyUpdatedAt] is `null` but a key
+     * exists, the fallback to [DriverRoadflareKey.createdAt] is also persisted
+     * via [DriverRoadflareRepository.updateKeyUpdatedAt] — this mirrors
+     * [ensureFollowersHaveCurrentKey] so a future Kind 30012 publish does not
+     * fall through to [DriverRoadflareStateEvent.create]'s wall-clock fallback
+     * and silently advance the public `key_updated_at` tag.
      *
      * @return true if the key was sent; false if no key is configured yet or send failed.
      */
@@ -314,7 +330,10 @@ class RoadflareKeyManager(
         followerPubkey: String
     ): Boolean {
         val key = repository.getRoadflareKey() ?: return false
-        val keyUpdatedAt = repository.getKeyUpdatedAt() ?: key.createdAt
+        val keyUpdatedAt = repository.getKeyUpdatedAt() ?: run {
+            repository.updateKeyUpdatedAt(key.createdAt)
+            key.createdAt
+        }
         val sent = sendKeyToFollower(signer, followerPubkey, key, keyUpdatedAt)
         if (sent) {
             repository.markFollowerKeySent(followerPubkey, key.version)

--- a/common/src/main/java/com/ridestr/common/roadflare/RoadflareKeyManager.kt
+++ b/common/src/main/java/com/ridestr/common/roadflare/RoadflareKeyManager.kt
@@ -322,9 +322,8 @@ class RoadflareKeyManager(
      * If [DriverRoadflareRepository.getKeyUpdatedAt] is `null` but a key
      * exists, the fallback to [DriverRoadflareKey.createdAt] is also persisted
      * via [DriverRoadflareRepository.updateKeyUpdatedAt] — this mirrors
-     * [ensureFollowersHaveCurrentKey] so a future Kind 30012 publish does not
-     * fall through to [DriverRoadflareStateEvent.create]'s wall-clock fallback
-     * and silently advance the public `key_updated_at` tag.
+     * [ensureFollowersHaveCurrentKey] so the rider's stored key share carries
+     * the same `keyUpdatedAt` value any future Kind 30012 publish will emit.
      *
      * @return true if the key was sent; false if no key is configured yet or send failed.
      */

--- a/common/src/main/java/com/ridestr/common/roadflare/RoadflareKeyManager.kt
+++ b/common/src/main/java/com/ridestr/common/roadflare/RoadflareKeyManager.kt
@@ -298,12 +298,15 @@ class RoadflareKeyManager(
 
         if (existing.approved) {
             // Approved re-add — re-deliver the current key. State unchanged, no Kind 30012 republish.
+            val hasKey = repository.getRoadflareKey() != null
             val keySent = resendCurrentKey(signer, followerPubkey)
             return if (keySent) {
                 Log.d(TAG, "Re-sent key to approved follower ${followerPubkey.take(8)}...")
                 FollowNotificationResult.KeyResent
-            } else {
+            } else if (!hasKey) {
                 FollowNotificationResult.Failed("no current key to resend")
+            } else {
+                FollowNotificationResult.Failed("Kind 3186 publish failed")
             }
         }
 

--- a/common/src/main/java/com/ridestr/common/roadflare/RoadflareKeyManager.kt
+++ b/common/src/main/java/com/ridestr/common/roadflare/RoadflareKeyManager.kt
@@ -246,12 +246,16 @@ class RoadflareKeyManager(
      * signal when their stored copy of the driver's RoadFlare key is unavailable
      * (fresh install, transient relay failure during backup restore, etc.).
      *
-     * Receiving Kind 3187 NEVER rotates the key or advances
-     * [DriverRoadflareRepository.getKeyUpdatedAt] — other followers' stored keys
-     * are not invalidated by one rider re-adding the driver. See
-     * [FollowNotificationResult] for the per-state outcomes.
+     * Receiving Kind 3187 NEVER rotates the key, advances
+     * [DriverRoadflareRepository.getKeyUpdatedAt], or republishes Kind 30012 —
+     * other followers' stored keys are not invalidated by one rider re-adding
+     * the driver. See [FollowNotificationResult] for the per-state outcomes.
      *
-     * @param signer The driver's identity signer (for publishing Kind 3186/30012).
+     * Muted riders are left alone: the driver's "Remove" decision is preserved
+     * (matches the cross-device sync invariant in
+     * `RoadflareDriverCoordinator.mergeMutedLists`).
+     *
+     * @param signer The driver's identity signer (for publishing Kind 3186).
      * @param followerPubkey The rider's pubkey from the Kind 3187 event.
      * @param riderName The rider's display name from the notification body.
      * @return The action taken; the call site uses this to decide whether to
@@ -278,22 +282,10 @@ class RoadflareKeyManager(
         }
 
         if (repository.isMuted(followerPubkey)) {
-            // Muted re-add — unmute and re-deliver the current key.
-            // Does NOT rotate; mute removal is published via Kind 30012 with
-            // keyUpdatedAt unchanged so other followers' stored keys stay valid.
-            repository.unmuteRider(followerPubkey)
-            val keySent = resendCurrentKey(signer, followerPubkey)
-            // Publish state regardless of key send outcome — the unmute itself is observable.
-            val newState = repository.state.value
-            if (newState != null) {
-                nostrService.publishDriverRoadflareState(signer, newState)
-            }
-            return if (keySent) {
-                Log.d(TAG, "Unmuted and re-sent key to ${followerPubkey.take(8)}...")
-                FollowNotificationResult.UnmutedAndKeyResent
-            } else {
-                FollowNotificationResult.Failed("unmuted but key resend failed")
-            }
+            // Muted re-add — preserve the driver's "Remove" decision.
+            // Auto-unmute would conflict with mergeMutedLists' "once muted, always
+            // muted" cross-device invariant and silently bypass driver consent.
+            return FollowNotificationResult.AlreadyMuted
         }
 
         if (existing.approved) {

--- a/common/src/main/java/com/ridestr/common/roadflare/RoadflareKeyManager.kt
+++ b/common/src/main/java/com/ridestr/common/roadflare/RoadflareKeyManager.kt
@@ -240,19 +240,94 @@ class RoadflareKeyManager(
     }
 
     /**
-     * Handle a new follow notification from a rider.
-     * Adds follower as pending (requires separate approval by driver).
+     * Handle a Kind 3187 follow notification from a rider.
      *
-     * @param followerPubkey The rider's pubkey
-     * @param riderName The rider's display name (from notification)
-     * @return true if follower was added as pending
+     * Kind 3187 is used by riders for both first follows AND as a delivery-retry
+     * signal when their stored copy of the driver's RoadFlare key is unavailable
+     * (fresh install, transient relay failure during backup restore, etc.).
+     *
+     * Receiving Kind 3187 NEVER rotates the key or advances
+     * [DriverRoadflareRepository.getKeyUpdatedAt] — other followers' stored keys
+     * are not invalidated by one rider re-adding the driver. See
+     * [FollowNotificationResult] for the per-state outcomes.
+     *
+     * @param signer The driver's identity signer (for publishing Kind 3186/30012).
+     * @param followerPubkey The rider's pubkey from the Kind 3187 event.
+     * @param riderName The rider's display name from the notification body.
+     * @return The action taken; the call site uses this to decide whether to
+     *   surface an OS notification (only for [FollowNotificationResult.AddedAsPending])
+     *   and whether to refresh profile backups.
      */
-    fun handleNewFollower(
+    suspend fun handleFollowNotification(
+        signer: NostrSigner,
         followerPubkey: String,
         riderName: String
+    ): FollowNotificationResult {
+        val existing = repository.state.value?.followers?.find { it.pubkey == followerPubkey }
+
+        if (existing == null) {
+            // New rider — add as pending; driver must approve via UI before key is sent.
+            // Preserves driver consent for genuinely new follows.
+            val added = addPendingFollower(followerPubkey, riderName)
+            return if (added) {
+                FollowNotificationResult.AddedAsPending
+            } else {
+                // Race: another path added them between our state read and add. Treat as pending.
+                FollowNotificationResult.AlreadyPending
+            }
+        }
+
+        if (repository.isMuted(followerPubkey)) {
+            // Muted re-add — unmute and re-deliver the current key.
+            // Does NOT rotate; mute removal is published via Kind 30012 with
+            // keyUpdatedAt unchanged so other followers' stored keys stay valid.
+            repository.unmuteRider(followerPubkey)
+            val keySent = resendCurrentKey(signer, followerPubkey)
+            // Publish state regardless of key send outcome — the unmute itself is observable.
+            val newState = repository.state.value
+            if (newState != null) {
+                nostrService.publishDriverRoadflareState(signer, newState)
+            }
+            return if (keySent) {
+                Log.d(TAG, "Unmuted and re-sent key to ${followerPubkey.take(8)}...")
+                FollowNotificationResult.UnmutedAndKeyResent
+            } else {
+                FollowNotificationResult.Failed("unmuted but key resend failed")
+            }
+        }
+
+        if (existing.approved) {
+            // Approved re-add — re-deliver the current key. State unchanged, no Kind 30012 republish.
+            val keySent = resendCurrentKey(signer, followerPubkey)
+            return if (keySent) {
+                Log.d(TAG, "Re-sent key to approved follower ${followerPubkey.take(8)}...")
+                FollowNotificationResult.KeyResent
+            } else {
+                FollowNotificationResult.Failed("no current key to resend")
+            }
+        }
+
+        // Pending (not yet approved) re-add — driver still owes an approval via UI.
+        return FollowNotificationResult.AlreadyPending
+    }
+
+    /**
+     * Re-send the current Kind 3186 key share to a specific follower.
+     * Uses the existing keyUpdatedAt — does NOT advance it.
+     *
+     * @return true if the key was sent; false if no key is configured yet or send failed.
+     */
+    private suspend fun resendCurrentKey(
+        signer: NostrSigner,
+        followerPubkey: String
     ): Boolean {
-        // Just add as pending - driver must approve separately
-        return addPendingFollower(followerPubkey, riderName)
+        val key = repository.getRoadflareKey() ?: return false
+        val keyUpdatedAt = repository.getKeyUpdatedAt() ?: key.createdAt
+        val sent = sendKeyToFollower(signer, followerPubkey, key, keyUpdatedAt)
+        if (sent) {
+            repository.markFollowerKeySent(followerPubkey, key.version)
+        }
+        return sent
     }
 
     /**

--- a/common/src/test/java/com/ridestr/common/nostr/events/DriverRoadflareStateEventTest.kt
+++ b/common/src/test/java/com/ridestr/common/nostr/events/DriverRoadflareStateEventTest.kt
@@ -1,0 +1,113 @@
+package com.ridestr.common.nostr.events
+
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
+import io.mockk.CapturingSlot
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Pins the public Kind 30012 tag emission against the wall-clock fallback
+ * hazard at the source. A null `keyUpdatedAt` MUST emit `"0"` (never the
+ * current wall-clock time), because the public `key_updated_at` tag is what
+ * riders compare against their stored value in `checkStaleKeys`. A wall-clock
+ * fallback would silently advance the tag and cause riders to flap into
+ * stale-key flagging until the next real publish corrects it.
+ *
+ * Companion to the Kind 3187 fix in PR #79: that PR pinned the invariant on
+ * the handler path; this test pins it at the source so future publish callers
+ * can't reintroduce the hazard.
+ */
+@RunWith(RobolectricTestRunner::class)
+class DriverRoadflareStateEventTest {
+
+    private fun mockSigner(): Pair<NostrSigner, CapturingSlot<Array<Array<String>>>> {
+        val tagsSlot = slot<Array<Array<String>>>()
+        val mockSigner = mockk<NostrSigner>(relaxed = true)
+        val mockEvent = mockk<Event>(relaxed = true)
+        every { mockSigner.pubKey } returns "d".repeat(64)
+        coEvery { mockSigner.nip44Encrypt(any(), any()) } returns "encrypted_content"
+        coEvery {
+            mockSigner.sign<Event>(
+                createdAt = any(),
+                kind = any(),
+                tags = capture(tagsSlot),
+                content = any()
+            )
+        } returns mockEvent
+        return Pair(mockSigner, tagsSlot)
+    }
+
+    @Test
+    fun `null keyUpdatedAt emits 0 not wall-clock`() = runBlocking {
+        val (signer, tagsSlot) = mockSigner()
+        val state = DriverRoadflareState(
+            roadflareKey = DriverRoadflareKey(
+                privateKey = "p".repeat(64),
+                publicKey = "k".repeat(64),
+                version = 1,
+                createdAt = 100L
+            ),
+            followers = emptyList(),
+            muted = emptyList(),
+            keyUpdatedAt = null,
+            lastBroadcastAt = null
+        )
+
+        DriverRoadflareStateEvent.create(signer, state)
+
+        val keyUpdatedAtTag = tagsSlot.captured.single { it[0] == "key_updated_at" }
+        assertEquals("0", keyUpdatedAtTag[1])
+        // Defense-in-depth: the wall-clock fallback would have produced a 10-digit
+        // timestamp around 1.7e9. "0" is unambiguously not a wall-clock value.
+        val nowSeconds = System.currentTimeMillis() / 1000
+        assertNotEquals(nowSeconds.toString(), keyUpdatedAtTag[1])
+    }
+
+    @Test
+    fun `non-null keyUpdatedAt is preserved verbatim`() = runBlocking {
+        val (signer, tagsSlot) = mockSigner()
+        val state = DriverRoadflareState(
+            roadflareKey = DriverRoadflareKey(
+                privateKey = "p".repeat(64),
+                publicKey = "k".repeat(64),
+                version = 2,
+                createdAt = 100L
+            ),
+            followers = emptyList(),
+            muted = emptyList(),
+            keyUpdatedAt = 4_242L,
+            lastBroadcastAt = null
+        )
+
+        DriverRoadflareStateEvent.create(signer, state)
+
+        val keyUpdatedAtTag = tagsSlot.captured.single { it[0] == "key_updated_at" }
+        assertEquals("4242", keyUpdatedAtTag[1])
+    }
+
+    @Test
+    fun `null roadflareKey emits 0 for key_version`() = runBlocking {
+        val (signer, tagsSlot) = mockSigner()
+        val state = DriverRoadflareState(
+            roadflareKey = null,
+            followers = emptyList(),
+            muted = emptyList(),
+            keyUpdatedAt = null,
+            lastBroadcastAt = null
+        )
+
+        DriverRoadflareStateEvent.create(signer, state)
+
+        val keyVersionTag = tagsSlot.captured.single { it[0] == "key_version" }
+        assertEquals("0", keyVersionTag[1])
+    }
+}

--- a/common/src/test/java/com/ridestr/common/roadflare/RoadflareKeyManagerTest.kt
+++ b/common/src/test/java/com/ridestr/common/roadflare/RoadflareKeyManagerTest.kt
@@ -5,7 +5,6 @@ import androidx.test.core.app.ApplicationProvider
 import com.ridestr.common.data.DriverRoadflareRepository
 import com.ridestr.common.nostr.NostrService
 import com.ridestr.common.nostr.events.DriverRoadflareKey
-import com.ridestr.common.nostr.events.DriverRoadflareState
 import com.ridestr.common.nostr.events.RoadflareFollower
 import com.ridestr.common.nostr.events.RoadflareKey
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
@@ -187,6 +186,11 @@ class RoadflareKeyManagerTest {
         val result = keyManager.handleFollowNotification(signer, alicePubkey, "Alice")
 
         assertTrue("expected Failed, got $result", result is FollowNotificationResult.Failed)
+        // The reason must distinguish "publish failed" from "no key configured" so a
+        // future maintainer can tell why the result was Failed without re-reading the SUT.
+        assertEquals("Kind 3186 publish failed", (result as FollowNotificationResult.Failed).reason)
+        // The publish was attempted exactly once.
+        coVerify(exactly = 1) { nostrService.publishRoadflareKeyShare(any(), eq(alicePubkey), any(), any()) }
         // markFollowerKeySent must NOT be called when the publish fails.
         val alice = repository.getFollowers().single { it.pubkey == alicePubkey }
         assertEquals(1, alice.keyVersionSent)

--- a/common/src/test/java/com/ridestr/common/roadflare/RoadflareKeyManagerTest.kt
+++ b/common/src/test/java/com/ridestr/common/roadflare/RoadflareKeyManagerTest.kt
@@ -178,49 +178,37 @@ class RoadflareKeyManagerTest {
     // ---------------------------------------------------------------------
 
     @Test
-    fun `re-add of muted follower unmutes and resends key without bumping keyUpdatedAt`() = runBlocking {
+    fun `re-add of muted follower is no-op and preserves driver's Remove decision`() = runBlocking {
+        // Auto-unmuting on Kind 3187 would silently bypass driver consent and
+        // conflict with mergeMutedLists' "once muted, always muted" cross-device
+        // invariant. The handler must leave muted re-adds alone.
         seedKey(version = 2, keyUpdatedAt = 2_000L)
         seedFollower(alicePubkey, approved = true, keyVersionSent = 1)
         repository.muteRider(alicePubkey, reason = "removed by driver")
 
-        val publishedStateSlot = slot<DriverRoadflareState>()
-        coEvery {
-            nostrService.publishDriverRoadflareState(any(), capture(publishedStateSlot))
-        } returns "evt-state"
-
         val result = keyManager.handleFollowNotification(signer, alicePubkey, "Alice")
 
-        assertEquals(FollowNotificationResult.UnmutedAndKeyResent, result)
+        assertEquals(FollowNotificationResult.AlreadyMuted, result)
         assertEquals(2_000L, repository.getKeyUpdatedAt())
-        assertFalse("Alice must no longer be muted", repository.isMuted(alicePubkey))
-
-        // Key share was sent.
-        coVerify(exactly = 1) { nostrService.publishRoadflareKeyShare(any(), eq(alicePubkey), any(), any()) }
-
-        // Kind 30012 was republished, with keyUpdatedAt PRESERVED.
-        coVerify(exactly = 1) { nostrService.publishDriverRoadflareState(any(), any()) }
-        assertEquals(2_000L, publishedStateSlot.captured.keyUpdatedAt)
-        assertTrue(
-            "muted list must shrink in published state",
-            publishedStateSlot.captured.muted.none { it.pubkey == alicePubkey }
-        )
+        assertTrue("Alice must remain muted", repository.isMuted(alicePubkey))
+        coVerify(exactly = 0) { nostrService.publishRoadflareKeyShare(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { nostrService.publishDriverRoadflareState(any(), any()) }
     }
 
     @Test
-    fun `re-add of muted follower without current key reports Failed but still unmutes and publishes`() = runBlocking {
-        // Driver has a follower record + a stale mute, but no local key (post-restore edge case).
+    fun `re-add of muted follower without current key is also no-op`() = runBlocking {
+        // Edge case: driver has a follower record + a stale mute but no local key
+        // (post-restore). The no-op contract holds regardless of key presence.
         seedFollower(alicePubkey, approved = true, keyVersionSent = 1)
         repository.muteRider(alicePubkey)
 
         val result = keyManager.handleFollowNotification(signer, alicePubkey, "Alice")
 
-        assertTrue("expected Failed, got $result", result is FollowNotificationResult.Failed)
-        // Unmute is observable even when key send fails — driver state must reflect the rider's intent.
-        assertFalse(repository.isMuted(alicePubkey))
-        coVerify(exactly = 1) { nostrService.publishDriverRoadflareState(any(), any()) }
-        coVerify(exactly = 0) { nostrService.publishRoadflareKeyShare(any(), any(), any(), any()) }
-        // keyUpdatedAt was null and stays null.
+        assertEquals(FollowNotificationResult.AlreadyMuted, result)
+        assertTrue(repository.isMuted(alicePubkey))
         assertNull(repository.getKeyUpdatedAt())
+        coVerify(exactly = 0) { nostrService.publishRoadflareKeyShare(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { nostrService.publishDriverRoadflareState(any(), any()) }
     }
 
     // ---------------------------------------------------------------------
@@ -282,5 +270,9 @@ class RoadflareKeyManagerTest {
         // Bob received a re-delivered key, but Alice did not.
         coVerify(exactly = 1) { nostrService.publishRoadflareKeyShare(any(), eq(bobPubkey), any(), any()) }
         coVerify(exactly = 0) { nostrService.publishRoadflareKeyShare(any(), eq(alicePubkey), any(), any()) }
+        // Pin the no-Kind-30012-republish invariant: any unexpected publishDriverRoadflareState
+        // would be a regression of the keyUpdatedAt-can-silently-advance hazard.
+        coVerify(exactly = 0) { nostrService.publishDriverRoadflareState(any(), any()) }
+        confirmVerified(nostrService)
     }
 }

--- a/common/src/test/java/com/ridestr/common/roadflare/RoadflareKeyManagerTest.kt
+++ b/common/src/test/java/com/ridestr/common/roadflare/RoadflareKeyManagerTest.kt
@@ -1,0 +1,286 @@
+package com.ridestr.common.roadflare
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.ridestr.common.data.DriverRoadflareRepository
+import com.ridestr.common.nostr.NostrService
+import com.ridestr.common.nostr.events.DriverRoadflareKey
+import com.ridestr.common.nostr.events.DriverRoadflareState
+import com.ridestr.common.nostr.events.RoadflareFollower
+import com.ridestr.common.nostr.events.RoadflareKey
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.confirmVerified
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Pins driver-side Kind 3187 follow-notification handling against
+ * variablefate/ridestr#78: re-add must NEVER rotate the shared
+ * RoadFlare key or advance keyUpdatedAt — other followers' stored
+ * keys must not go stale because one rider re-added the driver.
+ */
+@RunWith(RobolectricTestRunner::class)
+class RoadflareKeyManagerTest {
+
+    private lateinit var repository: DriverRoadflareRepository
+    private lateinit var nostrService: NostrService
+    private lateinit var signer: NostrSigner
+    private lateinit var keyManager: RoadflareKeyManager
+
+    private val alicePubkey = "a".repeat(64)
+    private val bobPubkey = "b".repeat(64)
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        // Clear persistent state across tests; the repository persists to SharedPreferences.
+        context.getSharedPreferences("roadflare_driver_state", Context.MODE_PRIVATE)
+            .edit().clear().commit()
+        repository = DriverRoadflareRepository(context)
+
+        nostrService = mockk(relaxed = true)
+        signer = mockk(relaxed = true)
+        coEvery {
+            nostrService.publishRoadflareKeyShare(any(), any(), any(), any())
+        } returns "evt-share"
+        coEvery {
+            nostrService.publishDriverRoadflareState(any(), any())
+        } returns "evt-state"
+
+        keyManager = RoadflareKeyManager(repository, nostrService)
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    private fun seedKey(version: Int, keyUpdatedAt: Long): DriverRoadflareKey {
+        val key = DriverRoadflareKey(
+            privateKey = "p".repeat(64),
+            publicKey = "k".repeat(64),
+            version = version,
+            createdAt = keyUpdatedAt
+        )
+        repository.setRoadflareKey(key)
+        repository.updateKeyUpdatedAt(keyUpdatedAt)
+        return key
+    }
+
+    private fun seedFollower(
+        pubkey: String,
+        approved: Boolean,
+        keyVersionSent: Int
+    ) {
+        repository.addFollower(
+            RoadflareFollower(
+                pubkey = pubkey,
+                name = "",
+                addedAt = 1_000L,
+                approved = approved,
+                keyVersionSent = keyVersionSent
+            )
+        )
+    }
+
+    // ---------------------------------------------------------------------
+    // New follower path
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun `new follow adds rider as pending and does not change keyUpdatedAt`() = runBlocking {
+        seedKey(version = 1, keyUpdatedAt = 1_000L)
+        seedFollower(alicePubkey, approved = true, keyVersionSent = 1)
+
+        val result = keyManager.handleFollowNotification(signer, bobPubkey, "Bob")
+
+        assertEquals(FollowNotificationResult.AddedAsPending, result)
+        assertEquals(1_000L, repository.getKeyUpdatedAt())
+        val bob = repository.getFollowers().single { it.pubkey == bobPubkey }
+        assertFalse("Bob must be pending until driver approves", bob.approved)
+        assertEquals(0, bob.keyVersionSent)
+
+        // Pinning the issue's regression contract: rider B following must not
+        // resend a key to rider A and must not republish Kind 30012.
+        coVerify(exactly = 0) { nostrService.publishRoadflareKeyShare(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { nostrService.publishDriverRoadflareState(any(), any()) }
+    }
+
+    @Test
+    fun `new follow does not affect existing approved follower's keyVersionSent`() = runBlocking {
+        seedKey(version = 1, keyUpdatedAt = 1_000L)
+        seedFollower(alicePubkey, approved = true, keyVersionSent = 1)
+
+        keyManager.handleFollowNotification(signer, bobPubkey, "Bob")
+
+        val alice = repository.getFollowers().single { it.pubkey == alicePubkey }
+        assertEquals(1, alice.keyVersionSent)
+        assertTrue(alice.approved)
+    }
+
+    // ---------------------------------------------------------------------
+    // Approved re-add path
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun `re-add of approved follower resends current key without bumping keyUpdatedAt`() = runBlocking {
+        seedKey(version = 1, keyUpdatedAt = 1_000L)
+        seedFollower(alicePubkey, approved = true, keyVersionSent = 1)
+
+        val keySlot = slot<RoadflareKey>()
+        val pubkeySlot = slot<String>()
+        val keyUpdatedAtSlot = slot<Long>()
+        coEvery {
+            nostrService.publishRoadflareKeyShare(
+                signer = any(),
+                followerPubKey = capture(pubkeySlot),
+                roadflareKey = capture(keySlot),
+                keyUpdatedAt = capture(keyUpdatedAtSlot)
+            )
+        } returns "evt-share"
+
+        val result = keyManager.handleFollowNotification(signer, alicePubkey, "Alice")
+
+        assertEquals(FollowNotificationResult.KeyResent, result)
+        assertEquals(1_000L, repository.getKeyUpdatedAt())
+        assertEquals(alicePubkey, pubkeySlot.captured)
+        assertEquals(1, keySlot.captured.version)
+        assertEquals(1_000L, keyUpdatedAtSlot.captured)
+        coVerify(exactly = 1) { nostrService.publishRoadflareKeyShare(any(), any(), any(), any()) }
+        // State is unchanged for an approved-rider re-delivery; no Kind 30012 republish.
+        coVerify(exactly = 0) { nostrService.publishDriverRoadflareState(any(), any()) }
+    }
+
+    @Test
+    fun `re-add of approved follower fails if no current key configured`() = runBlocking {
+        // No seedKey — driver lost local state but still has follower record.
+        seedFollower(alicePubkey, approved = true, keyVersionSent = 1)
+
+        val result = keyManager.handleFollowNotification(signer, alicePubkey, "Alice")
+
+        assertTrue("expected Failed result, got $result", result is FollowNotificationResult.Failed)
+        coVerify(exactly = 0) { nostrService.publishRoadflareKeyShare(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { nostrService.publishDriverRoadflareState(any(), any()) }
+    }
+
+    // ---------------------------------------------------------------------
+    // Muted re-add path
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun `re-add of muted follower unmutes and resends key without bumping keyUpdatedAt`() = runBlocking {
+        seedKey(version = 2, keyUpdatedAt = 2_000L)
+        seedFollower(alicePubkey, approved = true, keyVersionSent = 1)
+        repository.muteRider(alicePubkey, reason = "removed by driver")
+
+        val publishedStateSlot = slot<DriverRoadflareState>()
+        coEvery {
+            nostrService.publishDriverRoadflareState(any(), capture(publishedStateSlot))
+        } returns "evt-state"
+
+        val result = keyManager.handleFollowNotification(signer, alicePubkey, "Alice")
+
+        assertEquals(FollowNotificationResult.UnmutedAndKeyResent, result)
+        assertEquals(2_000L, repository.getKeyUpdatedAt())
+        assertFalse("Alice must no longer be muted", repository.isMuted(alicePubkey))
+
+        // Key share was sent.
+        coVerify(exactly = 1) { nostrService.publishRoadflareKeyShare(any(), eq(alicePubkey), any(), any()) }
+
+        // Kind 30012 was republished, with keyUpdatedAt PRESERVED.
+        coVerify(exactly = 1) { nostrService.publishDriverRoadflareState(any(), any()) }
+        assertEquals(2_000L, publishedStateSlot.captured.keyUpdatedAt)
+        assertTrue(
+            "muted list must shrink in published state",
+            publishedStateSlot.captured.muted.none { it.pubkey == alicePubkey }
+        )
+    }
+
+    @Test
+    fun `re-add of muted follower without current key reports Failed but still unmutes and publishes`() = runBlocking {
+        // Driver has a follower record + a stale mute, but no local key (post-restore edge case).
+        seedFollower(alicePubkey, approved = true, keyVersionSent = 1)
+        repository.muteRider(alicePubkey)
+
+        val result = keyManager.handleFollowNotification(signer, alicePubkey, "Alice")
+
+        assertTrue("expected Failed, got $result", result is FollowNotificationResult.Failed)
+        // Unmute is observable even when key send fails — driver state must reflect the rider's intent.
+        assertFalse(repository.isMuted(alicePubkey))
+        coVerify(exactly = 1) { nostrService.publishDriverRoadflareState(any(), any()) }
+        coVerify(exactly = 0) { nostrService.publishRoadflareKeyShare(any(), any(), any(), any()) }
+        // keyUpdatedAt was null and stays null.
+        assertNull(repository.getKeyUpdatedAt())
+    }
+
+    // ---------------------------------------------------------------------
+    // Pending re-add path
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun `re-add of pending follower is no-op and does not change state`() = runBlocking {
+        seedKey(version = 1, keyUpdatedAt = 1_000L)
+        seedFollower(alicePubkey, approved = false, keyVersionSent = 0)
+
+        val result = keyManager.handleFollowNotification(signer, alicePubkey, "Alice")
+
+        assertEquals(FollowNotificationResult.AlreadyPending, result)
+        val alice = repository.getFollowers().single { it.pubkey == alicePubkey }
+        assertFalse("Alice must remain pending until driver approves", alice.approved)
+        assertEquals(0, alice.keyVersionSent)
+        assertEquals(1_000L, repository.getKeyUpdatedAt())
+        coVerify(exactly = 0) { nostrService.publishRoadflareKeyShare(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { nostrService.publishDriverRoadflareState(any(), any()) }
+    }
+
+    // ---------------------------------------------------------------------
+    // Cross-rider isolation invariant — the headline bug from #78
+    // ---------------------------------------------------------------------
+
+    @Test
+    fun `rider B follow leaves rider A's stored key valid`() = runBlocking {
+        // Setup matches the issue's prescribed regression test:
+        // rider A is approved with the current key; rider B follows for the first time.
+        seedKey(version = 3, keyUpdatedAt = 3_000L)
+        seedFollower(alicePubkey, approved = true, keyVersionSent = 3)
+
+        keyManager.handleFollowNotification(signer, bobPubkey, "Bob")
+
+        // Driver's published keyUpdatedAt must be unchanged so rider A's
+        // checkStaleKeys() does not flag her stored key.
+        assertEquals(3_000L, repository.getKeyUpdatedAt())
+        val alice = repository.getFollowers().single { it.pubkey == alicePubkey }
+        assertEquals(3, alice.keyVersionSent)
+        coVerify(exactly = 0) { nostrService.publishRoadflareKeyShare(any(), eq(alicePubkey), any(), any()) }
+        coVerify(exactly = 0) { nostrService.publishDriverRoadflareState(any(), any()) }
+        confirmVerified(nostrService)
+    }
+
+    @Test
+    fun `rider B re-add leaves rider A's stored key valid`() = runBlocking {
+        // Same invariant under a different trigger: rider B is an approved
+        // follower re-adding the driver from a fresh install.
+        seedKey(version = 3, keyUpdatedAt = 3_000L)
+        seedFollower(alicePubkey, approved = true, keyVersionSent = 3)
+        seedFollower(bobPubkey, approved = true, keyVersionSent = 3)
+
+        keyManager.handleFollowNotification(signer, bobPubkey, "Bob")
+
+        assertEquals(3_000L, repository.getKeyUpdatedAt())
+        val alice = repository.getFollowers().single { it.pubkey == alicePubkey }
+        assertEquals(3, alice.keyVersionSent)
+        // Bob received a re-delivered key, but Alice did not.
+        coVerify(exactly = 1) { nostrService.publishRoadflareKeyShare(any(), eq(bobPubkey), any(), any()) }
+        coVerify(exactly = 0) { nostrService.publishRoadflareKeyShare(any(), eq(alicePubkey), any(), any()) }
+    }
+}

--- a/common/src/test/java/com/ridestr/common/roadflare/RoadflareKeyManagerTest.kt
+++ b/common/src/test/java/com/ridestr/common/roadflare/RoadflareKeyManagerTest.kt
@@ -159,6 +159,9 @@ class RoadflareKeyManagerTest {
         coVerify(exactly = 1) { nostrService.publishRoadflareKeyShare(any(), any(), any(), any()) }
         // State is unchanged for an approved-rider re-delivery; no Kind 30012 republish.
         coVerify(exactly = 0) { nostrService.publishDriverRoadflareState(any(), any()) }
+        // markFollowerKeySent must be called so the follower record stays in sync with what was sent.
+        val alice = repository.getFollowers().single { it.pubkey == alicePubkey }
+        assertEquals(1, alice.keyVersionSent)
     }
 
     @Test
@@ -171,6 +174,47 @@ class RoadflareKeyManagerTest {
         assertTrue("expected Failed result, got $result", result is FollowNotificationResult.Failed)
         coVerify(exactly = 0) { nostrService.publishRoadflareKeyShare(any(), any(), any(), any()) }
         coVerify(exactly = 0) { nostrService.publishDriverRoadflareState(any(), any()) }
+    }
+
+    @Test
+    fun `re-add of approved follower returns Failed when key share publish fails`() = runBlocking {
+        seedKey(version = 1, keyUpdatedAt = 1_000L)
+        seedFollower(alicePubkey, approved = true, keyVersionSent = 1)
+        coEvery {
+            nostrService.publishRoadflareKeyShare(any(), any(), any(), any())
+        } returns null
+
+        val result = keyManager.handleFollowNotification(signer, alicePubkey, "Alice")
+
+        assertTrue("expected Failed, got $result", result is FollowNotificationResult.Failed)
+        // markFollowerKeySent must NOT be called when the publish fails.
+        val alice = repository.getFollowers().single { it.pubkey == alicePubkey }
+        assertEquals(1, alice.keyVersionSent)
+        assertEquals(1_000L, repository.getKeyUpdatedAt())
+    }
+
+    @Test
+    fun `re-add of approved follower with null keyUpdatedAt persists fallback to repository`() = runBlocking {
+        // Edge case: driver has a key but keyUpdatedAt was never set (post-restore).
+        // resendCurrentKey must mirror ensureFollowersHaveCurrentKey and write the
+        // fallback back so a later Kind 30012 publish does not fall through to
+        // DriverRoadflareStateEvent.create's wall-clock fallback (which would
+        // silently advance the public key_updated_at tag).
+        val key = DriverRoadflareKey(
+            privateKey = "p".repeat(64),
+            publicKey = "k".repeat(64),
+            version = 1,
+            createdAt = 4_242L
+        )
+        repository.setRoadflareKey(key)
+        // Deliberately do NOT call updateKeyUpdatedAt — leave it null.
+        seedFollower(alicePubkey, approved = true, keyVersionSent = 1)
+        assertNull("setup precondition", repository.getKeyUpdatedAt())
+
+        val result = keyManager.handleFollowNotification(signer, alicePubkey, "Alice")
+
+        assertEquals(FollowNotificationResult.KeyResent, result)
+        assertEquals(4_242L, repository.getKeyUpdatedAt())
     }
 
     // ---------------------------------------------------------------------
@@ -191,6 +235,29 @@ class RoadflareKeyManagerTest {
         assertEquals(FollowNotificationResult.AlreadyMuted, result)
         assertEquals(2_000L, repository.getKeyUpdatedAt())
         assertTrue("Alice must remain muted", repository.isMuted(alicePubkey))
+        coVerify(exactly = 0) { nostrService.publishRoadflareKeyShare(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { nostrService.publishDriverRoadflareState(any(), any()) }
+    }
+
+    @Test
+    fun `muted pubkey with no followers record is still treated as muted`() = runBlocking {
+        // After cross-device sync, a mute entry can outlive its followers record
+        // (e.g., the rider unfollowed and Kind 30011 verification filtered them
+        // out of the followers list, but the mute entry survives via union-merge).
+        // The handler must NOT fall through to AddedAsPending and silently let
+        // the muted rider back in as pending.
+        seedKey(version = 1, keyUpdatedAt = 1_000L)
+        repository.muteRider(alicePubkey, reason = "removed by driver")
+        // No seedFollower(alice, ...) — alice is muted but not in followers list.
+
+        val result = keyManager.handleFollowNotification(signer, alicePubkey, "Alice")
+
+        assertEquals(FollowNotificationResult.AlreadyMuted, result)
+        assertTrue("alice must remain muted", repository.isMuted(alicePubkey))
+        assertTrue(
+            "alice must NOT be re-added as pending",
+            repository.getFollowers().none { it.pubkey == alicePubkey }
+        )
         coVerify(exactly = 0) { nostrService.publishRoadflareKeyShare(any(), any(), any(), any()) }
         coVerify(exactly = 0) { nostrService.publishDriverRoadflareState(any(), any()) }
     }

--- a/drivestr/src/main/java/com/drivestr/app/MainActivity.kt
+++ b/drivestr/src/main/java/com/drivestr/app/MainActivity.kt
@@ -363,40 +363,55 @@ fun DrivestrApp(settingsRepository: SettingsRepository) {
                     if (notification != null) {
                         when (notification.action) {
                             "follow" -> {
-                                // Check if already a follower
-                                val existingFollowers = driverRoadflareRepo.state.value?.followers ?: emptyList()
-                                if (existingFollowers.none { it.pubkey == notification.riderPubKey }) {
-                                    android.util.Log.d("MainActivity", "New RoadFlare follow request from: ${notification.riderName} (${notification.riderPubKey.take(16)})")
+                                val result = roadflareKeyManager.handleFollowNotification(
+                                    signer = signer,
+                                    followerPubkey = notification.riderPubKey,
+                                    riderName = notification.riderName
+                                )
 
-                                    // Add as pending follower - driver must approve in RoadflareTab
-                                    roadflareKeyManager.handleNewFollower(notification.riderPubKey, notification.riderName)
+                                when (result) {
+                                    is com.ridestr.common.roadflare.FollowNotificationResult.AddedAsPending -> {
+                                        android.util.Log.d("MainActivity", "New RoadFlare follow request from: ${notification.riderName} (${notification.riderPubKey.take(16)})")
 
-                                    // Show OS notification so driver knows about the new follower
-                                    val displayName = notification.riderName.ifEmpty { notification.riderPubKey.take(8) + "..." }
-                                    val tapIntent = android.content.Intent(context, MainActivity::class.java).apply {
-                                        flags = android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP or android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP
-                                        putExtra("open_tab", "ROADFLARE")
+                                        // Show OS notification so driver knows about the new follower
+                                        val displayName = notification.riderName.ifEmpty { notification.riderPubKey.take(8) + "..." }
+                                        val tapIntent = android.content.Intent(context, MainActivity::class.java).apply {
+                                            flags = android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP or android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP
+                                            putExtra("open_tab", "ROADFLARE")
+                                        }
+                                        val pendingIntent = android.app.PendingIntent.getActivity(
+                                            context, notification.riderPubKey.hashCode(),
+                                            tapIntent, android.app.PendingIntent.FLAG_IMMUTABLE or android.app.PendingIntent.FLAG_UPDATE_CURRENT
+                                        )
+                                        val notif = androidx.core.app.NotificationCompat.Builder(context, com.ridestr.common.notification.NotificationHelper.CHANNEL_FOLLOW_REQUEST)
+                                            .setSmallIcon(android.R.drawable.ic_menu_add)
+                                            .setContentTitle("New Follow Request")
+                                            .setContentText("$displayName wants to add you to their driver network")
+                                            .setPriority(androidx.core.app.NotificationCompat.PRIORITY_DEFAULT)
+                                            .setContentIntent(pendingIntent)
+                                            .setAutoCancel(true)
+                                            .build()
+                                        com.ridestr.common.notification.NotificationHelper.showNotification(
+                                            context,
+                                            com.ridestr.common.notification.NotificationHelper.NOTIFICATION_ID_FOLLOW_REQUEST + kotlin.math.abs(notification.riderPubKey.hashCode() % 10000),
+                                            notif
+                                        )
+
+                                        profileSyncManager.backupProfileData()
                                     }
-                                    val pendingIntent = android.app.PendingIntent.getActivity(
-                                        context, notification.riderPubKey.hashCode(),
-                                        tapIntent, android.app.PendingIntent.FLAG_IMMUTABLE or android.app.PendingIntent.FLAG_UPDATE_CURRENT
-                                    )
-                                    val notif = androidx.core.app.NotificationCompat.Builder(context, com.ridestr.common.notification.NotificationHelper.CHANNEL_FOLLOW_REQUEST)
-                                        .setSmallIcon(android.R.drawable.ic_menu_add)
-                                        .setContentTitle("New Follow Request")
-                                        .setContentText("$displayName wants to add you to their driver network")
-                                        .setPriority(androidx.core.app.NotificationCompat.PRIORITY_DEFAULT)
-                                        .setContentIntent(pendingIntent)
-                                        .setAutoCancel(true)
-                                        .build()
-                                    com.ridestr.common.notification.NotificationHelper.showNotification(
-                                        context,
-                                        com.ridestr.common.notification.NotificationHelper.NOTIFICATION_ID_FOLLOW_REQUEST + kotlin.math.abs(notification.riderPubKey.hashCode() % 10000),
-                                        notif
-                                    )
-
-                                    // Backup updated state to Nostr
-                                    profileSyncManager.backupProfileData()
+                                    is com.ridestr.common.roadflare.FollowNotificationResult.UnmutedAndKeyResent -> {
+                                        android.util.Log.d("MainActivity", "Re-delivered key to previously-muted ${notification.riderPubKey.take(16)}")
+                                        profileSyncManager.backupProfileData()
+                                    }
+                                    is com.ridestr.common.roadflare.FollowNotificationResult.KeyResent -> {
+                                        android.util.Log.d("MainActivity", "Re-delivered key to approved ${notification.riderPubKey.take(16)}")
+                                    }
+                                    is com.ridestr.common.roadflare.FollowNotificationResult.AlreadyPending -> {
+                                        android.util.Log.d("MainActivity", "Follow notification from pending ${notification.riderPubKey.take(16)} — awaiting driver approval")
+                                    }
+                                    is com.ridestr.common.roadflare.FollowNotificationResult.Failed -> {
+                                        android.util.Log.w("MainActivity", "Follow notification handling failed for ${notification.riderPubKey.take(16)}: ${result.reason}")
+                                    }
                                 }
                             }
                             "unfollow" -> {

--- a/drivestr/src/main/java/com/drivestr/app/MainActivity.kt
+++ b/drivestr/src/main/java/com/drivestr/app/MainActivity.kt
@@ -86,6 +86,7 @@ import com.ridestr.common.sync.RideHistorySyncAdapter
 import com.ridestr.common.sync.ProfileSyncAdapter
 import com.ridestr.common.data.DriverRoadflareRepository
 import com.ridestr.common.sync.DriverRoadflareSyncAdapter
+import com.ridestr.common.roadflare.FollowNotificationResult
 import com.ridestr.common.roadflare.RoadflareKeyManager
 import com.ridestr.common.nostr.events.RoadflareFollowNotifyEvent
 import com.drivestr.app.service.RoadflareListenerService
@@ -370,7 +371,7 @@ fun DrivestrApp(settingsRepository: SettingsRepository) {
                                 )
 
                                 when (result) {
-                                    is com.ridestr.common.roadflare.FollowNotificationResult.AddedAsPending -> {
+                                    is FollowNotificationResult.AddedAsPending -> {
                                         android.util.Log.d("MainActivity", "New RoadFlare follow request from: ${notification.riderName} (${notification.riderPubKey.take(16)})")
 
                                         // Show OS notification so driver knows about the new follower
@@ -399,17 +400,16 @@ fun DrivestrApp(settingsRepository: SettingsRepository) {
 
                                         profileSyncManager.backupProfileData()
                                     }
-                                    is com.ridestr.common.roadflare.FollowNotificationResult.UnmutedAndKeyResent -> {
-                                        android.util.Log.d("MainActivity", "Re-delivered key to previously-muted ${notification.riderPubKey.take(16)}")
-                                        profileSyncManager.backupProfileData()
-                                    }
-                                    is com.ridestr.common.roadflare.FollowNotificationResult.KeyResent -> {
+                                    is FollowNotificationResult.KeyResent -> {
                                         android.util.Log.d("MainActivity", "Re-delivered key to approved ${notification.riderPubKey.take(16)}")
                                     }
-                                    is com.ridestr.common.roadflare.FollowNotificationResult.AlreadyPending -> {
+                                    is FollowNotificationResult.AlreadyMuted -> {
+                                        android.util.Log.d("MainActivity", "Follow notification from muted ${notification.riderPubKey.take(16)} — preserving driver's Remove decision")
+                                    }
+                                    is FollowNotificationResult.AlreadyPending -> {
                                         android.util.Log.d("MainActivity", "Follow notification from pending ${notification.riderPubKey.take(16)} — awaiting driver approval")
                                     }
-                                    is com.ridestr.common.roadflare.FollowNotificationResult.Failed -> {
+                                    is FollowNotificationResult.Failed -> {
                                         android.util.Log.w("MainActivity", "Follow notification handling failed for ${notification.riderPubKey.take(16)}: ${result.reason}")
                                     }
                                 }


### PR DESCRIPTION
Closes #78.

## Summary

Reframes the drivestr Kind 3187 follow-notification handler so that one rider
re-adding a driver cannot invalidate other riders' stored RoadFlare keys.

## Bug as found in current code

The issue body and the iOS-side ADR-0013 both describe the bug as "Kind 3187
triggers a full key rotation." On the **drivestr** side that framing turns out
to be slightly off — `rotateKey()` is reached only from the explicit driver-UI
mute/remove paths plus the developer "Rotate Key" debug button, never from the
Kind 3187 listener. The headline symptom from #78 ("rider B follows ⇒ rider A's
stored key marked stale") cannot reproduce on drivestr today.

What is genuinely broken: the Kind 3187 listener silently ignores every event
from a pubkey that's already in `followers` (regardless of state), so the
re-delivery semantic the iOS workaround in roadflare-ios#76 depends on
isn't there. Concrete gaps:

| Trigger case                              | Old behavior         | New behavior                                              |
| ----------------------------------------- | -------------------- | --------------------------------------------------------- |
| New pubkey                                | Add as pending + OS notification | Unchanged — preserves driver consent for new follows |
| Existing pubkey, **muted**                | Silently ignored | Logged no-op (`AlreadyMuted`); driver re-approves through the RoadFlare tab to restore. Avoids fighting `RoadflareDriverCoordinator.mergeMutedLists`' "once muted, always muted" sync invariant and keeps the driver's "Remove" decision intact |
| Existing pubkey, **approved**             | Silently ignored — rider can't recover from a transient delivery failure | Re-deliver Kind 3186; no Kind 30012 republish (state is unchanged) |
| Existing pubkey, **pending** (un-approved) | Silently ignored | No-op — driver still owes an approval via UI |

The `keyUpdatedAt` invariant — never advance from any Kind 3187 path — is the
cross-rider isolation property the new tests pin. It is what would have caught
the bug if it had been reachable.

### Departure from the issue prescription

The issue's "Proposed fix" #1 says "If the rider is on the mute list, take them
off." This PR deliberately does NOT do that. Auto-unmuting on Kind 3187 would
silently bypass driver consent for the "Remove" action AND conflict with
`RoadflareDriverCoordinator.mergeMutedLists` (documented invariant: "once
muted, always muted — auto-unmute via sync is intentionally blocked"). A
multi-device driver would have the unmute reverted by the next
`ensureStateSynced()` union-merge. The narrow fix here addresses the genuine
gaps (approved + pending re-adds) without that consent regression. To restore
a removed rider the driver re-approves via the RoadFlare tab.

## Code change

- `common/src/main/java/com/ridestr/common/roadflare/FollowNotificationResult.kt` — new sealed class with five variants: `AddedAsPending`, `AlreadyPending`, `AlreadyMuted`, `KeyResent`, `Failed`.
- `common/src/main/java/com/ridestr/common/roadflare/RoadflareKeyManager.kt` — replaces `handleNewFollower(pubkey, name)` with `handleFollowNotification(signer, pubkey, name)`. Mute check runs first so a stale muted entry without a `followers` record (post-sync) is not bypassed. New `resendCurrentKey(...)` private helper mirrors `ensureFollowersHaveCurrentKey`'s null-fallback persistence so a future Kind 30012 publish does not fall through to `DriverRoadflareStateEvent.create`'s wall-clock fallback.
- `drivestr/src/main/java/com/drivestr/app/MainActivity.kt` — Kind 3187 `"follow"` branch now delegates to the new API and reacts on the typed result. OS notification only on `AddedAsPending`; profile backup only on `AddedAsPending`.
- `common/src/test/java/com/ridestr/common/roadflare/RoadflareKeyManagerTest.kt` — Robolectric + MockK suite (12 cases) pinning all four trigger cases plus the cross-rider invariant, the muted-without-followers-record edge case, the publish-failure path, and the null-keyUpdatedAt write-back.

## Why we kept the approval gate for genuinely-new follows

The issue's prescribed unified fix ("re-deliver the current Kind 3186 key
share") would skip the approve-via-UI gate for first-time follows and just
auto-send the key. That is a consent regression — the driver loses the ability
to deny a follow request before any key is ever shared. The PR keeps the
existing approval flow for new pubkeys (the OS notification + driver-side
approval is unchanged) and applies the delivery-retry semantic only to existing
approved followers, which is the case the iOS workaround in roadflare-ios#76
actually unblocks.

## Coordination with iOS

iOS shipped the rider-side workaround in roadflare-ios#76 (try
`restoreKeyFromBackup` first; only send Kind 3187 if that fails). With this PR
the two halves connect: when the iOS workaround does fall back to Kind 3187 —
either because the rider is genuinely new from the driver's perspective or
because the relay was unreachable during restore — the driver now responds the
right way (re-deliver) instead of dropping the event.

## Test plan

- [x] `:common:testDebugUnitTest` — 12 tests, all green
- [x] `:drivestr:testDebugUnitTest` — full suite still passes
- [x] `:common:assembleDebug` clean
- [x] `:drivestr:assembleDebug` clean
- [ ] Manual: build drivestr + 3 rider clients, follow from all 3, verify a 4th rider following does not invalidate keys for the first 3 (the issue's manual repro)
- [ ] Manual: drivestr "Remove" rider from RoadflareTab, then re-add from rider; verify rider stays muted (driver must re-approve via UI to restore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)