### PR TITLE
feat(drivestr): per-follower lightweight mute (#80)

### DIFF
--- a/common/src/main/java/com/ridestr/common/coordinator/RoadflareDriverCoordinator.kt
+++ b/common/src/main/java/com/ridestr/common/coordinator/RoadflareDriverCoordinator.kt
@@ -300,6 +300,11 @@ class RoadflareDriverCoordinator(
      * - `approved` = logical-OR (once approved, stays approved)
      * - `keyVersionSent` = max, clamped to [selectedKeyVersion] (prevents phantom sent-key claims)
      * - `addedAt` = min (preserve the earliest known follow time)
+     * - `mutedAt` = earliest non-null wins (issue #80 lightweight mute). Bias toward "muted":
+     *   if either side has the lightweight mute set, keep it. The min-of-non-nulls preserves
+     *   the original mute timestamp (Kind 30177 reconciliation uses last-write-wins on its own
+     *   timestamp, not on this field, so this merge strategy is safe — it can't lose state
+     *   that Kind 30177 reconciliation will then re-apply).
      *
      * If `remoteUpdatedAt > localUpdatedAt`, local-only followers are pruned on the assumption
      * that the remote state is authoritative for removals. If local is newer, local additions
@@ -326,10 +331,18 @@ class RoadflareDriverCoordinator(
                 if (mergedVersion > selectedKeyVersion) {
                     Log.w(TAG, "Clamped keyVersionSent $mergedVersion→$selectedKeyVersion for ${follower.pubkey.take(8)}")
                 }
+                // Lightweight-mute (issue #80) merge: preserve mute from whichever side has it.
+                // If both sides have a value, take the earlier one (first-mute timestamp).
+                val mergedMutedAt = when {
+                    existing.mutedAt != null && follower.mutedAt != null ->
+                        minOf(existing.mutedAt, follower.mutedAt)
+                    else -> existing.mutedAt ?: follower.mutedAt
+                }
                 byPubkey[follower.pubkey] = existing.copy(
                     approved = existing.approved || follower.approved,
                     keyVersionSent = clampedVersion,
-                    addedAt = minOf(existing.addedAt, follower.addedAt)
+                    addedAt = minOf(existing.addedAt, follower.addedAt),
+                    mutedAt = mergedMutedAt
                 )
             }
         }

--- a/common/src/main/java/com/ridestr/common/data/DriverRoadflareRepository.kt
+++ b/common/src/main/java/com/ridestr/common/data/DriverRoadflareRepository.kt
@@ -440,6 +440,30 @@ class DriverRoadflareRepository(context: Context) {
         return _state.value?.followers?.any { it.pubkey == pubkey && it.mutedAt != null } ?: false
     }
 
+    // In-memory flag (resets across process restarts) tracking whether the lightweight-mute
+    // reconciliation against Kind 30177 has run at least once this session.
+    //
+    // Why: on a fresh device first key-import the local follower list and mute set are empty
+    // until both Kind 30012 sync AND Kind 30177 mute reconciliation complete. Auto-backup
+    // hooks (settings hash, vehicles) can fire BEFORE that, and a publish with an empty local
+    // mute list would silently overwrite the remote `muted_pubkeys` set on Kind 30177 — wiping
+    // cross-device mutes before reconciliation ever sees them.
+    //
+    // Consumed by [ProfileSyncAdapter.publishToNostr]: when this flag is false the publish
+    // path preserves the remote `muted_pubkeys` instead of trusting the (possibly empty) local
+    // list. Once reconciliation has run, local is authoritative and an empty local list is
+    // treated as "user unmuted everyone" — i.e., a deliberate empty publish.
+    @Volatile
+    private var muteReconciledThisSession: Boolean = false
+
+    /** True once [markMuteReconciled] has been called in this process lifetime. */
+    fun isMuteReconciled(): Boolean = muteReconciledThisSession
+
+    /** Mark the lightweight-mute reconciliation as having run at least once this session. */
+    fun markMuteReconciled() {
+        muteReconciledThisSession = true
+    }
+
     /**
      * Update last broadcast timestamp.
      */

--- a/common/src/main/java/com/ridestr/common/data/DriverRoadflareRepository.kt
+++ b/common/src/main/java/com/ridestr/common/data/DriverRoadflareRepository.kt
@@ -212,6 +212,10 @@ class DriverRoadflareRepository(context: Context) {
     /**
      * Get follower pubkeys that have the current key version and are approved.
      * Used for location broadcast subscriptions.
+     *
+     * Excludes followers muted via either path:
+     * - Heavyweight mute via [MutedRider] / `state.muted` (key rotation, "Remove" UX).
+     * - Lightweight mute via [RoadflareFollower.mutedAt] (issue #80, "Mute" UX).
      */
     fun getActiveFollowerPubkeys(): List<String> {
         val state = _state.value ?: return emptyList()
@@ -224,20 +228,27 @@ class DriverRoadflareRepository(context: Context) {
                 val isApproved = f.approved
                 val hasCurrentKey = f.keyVersionSent == currentVersion
                 val isMuted = f.pubkey in mutedPubkeys
-                val isActive = isApproved && hasCurrentKey && !isMuted
+                val isLightMuted = f.mutedAt != null
+                val isActive = isApproved && hasCurrentKey && !isMuted && !isLightMuted
                 if (!isActive) {
-                    android.util.Log.d("RoadflareRepo", "Follower ${f.pubkey.take(8)} NOT active: approved=$isApproved, keyVersionSent=${f.keyVersionSent} vs current=$currentVersion, muted=$isMuted")
+                    android.util.Log.d("RoadflareRepo", "Follower ${f.pubkey.take(8)} NOT active: approved=$isApproved, keyVersionSent=${f.keyVersionSent} vs current=$currentVersion, muted=$isMuted, lightMuted=$isLightMuted")
                 }
             }
         }
 
         return state.followers
-            .filter { it.approved && it.keyVersionSent == currentVersion && it.pubkey !in mutedPubkeys }
+            .filter {
+                it.approved &&
+                    it.keyVersionSent == currentVersion &&
+                    it.pubkey !in mutedPubkeys &&
+                    it.mutedAt == null
+            }
             .map { it.pubkey }
     }
 
     /**
      * Get approved followers who need the current key (haven't received it yet).
+     * Excludes both heavyweight-muted ([MutedRider]) and lightweight-muted ([RoadflareFollower.mutedAt]) entries.
      */
     fun getFollowersNeedingKey(): List<RoadflareFollower> {
         val state = _state.value ?: return emptyList()
@@ -245,7 +256,12 @@ class DriverRoadflareRepository(context: Context) {
         val mutedPubkeys = state.muted.map { it.pubkey }.toSet()
 
         return state.followers
-            .filter { it.approved && it.keyVersionSent < currentVersion && it.pubkey !in mutedPubkeys }
+            .filter {
+                it.approved &&
+                    it.keyVersionSent < currentVersion &&
+                    it.pubkey !in mutedPubkeys &&
+                    it.mutedAt == null
+            }
     }
 
     /**
@@ -352,6 +368,76 @@ class DriverRoadflareRepository(context: Context) {
      */
     fun isMuted(pubkey: String): Boolean {
         return _state.value?.muted?.any { it.pubkey == pubkey } ?: false
+    }
+
+    // ── Lightweight per-follower mute (issue #80) ─────────────────────────────
+    //
+    // Distinct from the heavyweight [MutedRider] / "Remove" path above:
+    // - No key rotation; just suppresses Kind 3186 delivery for one follower.
+    // - Synced cross-device via Kind 30177's `muted_pubkeys` (last-write-wins),
+    //   not via Kind 30012.
+
+    /**
+     * Set the lightweight-mute timestamp on a single follower.
+     * No-op if the follower is not present in the current state.
+     *
+     * @param pubkey Follower pubkey to mute.
+     * @param mutedAt Timestamp (epoch seconds) recording when the mute took effect.
+     *   Used as the comparison value for last-write-wins reconciliation against
+     *   remote Kind 30177 backups.
+     * @return true if a follower row was updated; false if no matching follower exists.
+     */
+    fun setFollowerMuted(pubkey: String, mutedAt: Long): Boolean {
+        val current = _state.value ?: return false
+        if (current.followers.none { it.pubkey == pubkey }) return false
+
+        _state.value = current.copy(
+            followers = current.followers.map {
+                if (it.pubkey == pubkey) it.copy(mutedAt = mutedAt) else it
+            },
+            updatedAt = System.currentTimeMillis() / 1000
+        )
+        saveState()
+        return true
+    }
+
+    /**
+     * Clear the lightweight-mute timestamp on a single follower.
+     * No-op if the follower is not present.
+     *
+     * @return true if a follower row was updated; false if no matching follower exists.
+     */
+    fun setFollowerUnmuted(pubkey: String): Boolean {
+        val current = _state.value ?: return false
+        if (current.followers.none { it.pubkey == pubkey }) return false
+
+        _state.value = current.copy(
+            followers = current.followers.map {
+                if (it.pubkey == pubkey) it.copy(mutedAt = null) else it
+            },
+            updatedAt = System.currentTimeMillis() / 1000
+        )
+        saveState()
+        return true
+    }
+
+    /**
+     * Pubkeys of followers currently lightweight-muted (per-follower mutedAt non-null).
+     * Order is not significant (matches Kind 30177's `muted_pubkeys` array semantics).
+     */
+    fun getMutedFollowerPubkeys(): List<String> {
+        return _state.value?.followers
+            ?.filter { it.mutedAt != null }
+            ?.map { it.pubkey }
+            ?: emptyList()
+    }
+
+    /**
+     * Check if a follower is lightweight-muted.
+     * Independent of [isMuted] (which checks the heavyweight [MutedRider] list).
+     */
+    fun isFollowerMuted(pubkey: String): Boolean {
+        return _state.value?.followers?.any { it.pubkey == pubkey && it.mutedAt != null } ?: false
     }
 
     /**

--- a/common/src/main/java/com/ridestr/common/nostr/NostrService.kt
+++ b/common/src/main/java/com/ridestr/common/nostr/NostrService.kt
@@ -1127,13 +1127,16 @@ class NostrService internal constructor(
      * @param vehicles List of vehicles to backup (driver)
      * @param savedLocations List of saved locations to backup (rider)
      * @param settings Settings backup data
+     * @param mutedFollowerPubkeys Hex pubkeys of lightweight-muted RoadFlare followers (issue #80).
+     *   Empty for non-driver apps; field is omitted from the wire payload when empty.
      * @return Event ID if successful, null on failure
      */
     suspend fun publishProfileBackup(
         vehicles: List<Vehicle>,
         savedLocations: List<SavedLocation>,
-        settings: SettingsBackup
-    ): String? = profileBackupService.publishProfileBackup(vehicles, savedLocations, settings)
+        settings: SettingsBackup,
+        mutedFollowerPubkeys: List<String> = emptyList()
+    ): String? = profileBackupService.publishProfileBackup(vehicles, savedLocations, settings, mutedFollowerPubkeys)
 
     /**
      * Fetch the user's profile backup from Nostr relays.

--- a/common/src/main/java/com/ridestr/common/nostr/ProfileBackupService.kt
+++ b/common/src/main/java/com/ridestr/common/nostr/ProfileBackupService.kt
@@ -264,12 +264,15 @@ class ProfileBackupService(
      * @param vehicles List of vehicles to backup (driver)
      * @param savedLocations List of saved locations to backup (rider)
      * @param settings Settings backup data
+     * @param mutedFollowerPubkeys Hex pubkeys of lightweight-muted RoadFlare followers (issue #80).
+     *   Empty for non-driver apps; field is omitted from the wire payload when empty.
      * @return Event ID if successful, null on failure
      */
     suspend fun publishProfileBackup(
         vehicles: List<Vehicle>,
         savedLocations: List<SavedLocation>,
-        settings: SettingsBackup
+        settings: SettingsBackup,
+        mutedFollowerPubkeys: List<String> = emptyList()
     ): String? {
         val signer = keyManager.getSigner()
         if (signer == null) {
@@ -284,10 +287,10 @@ class ProfileBackupService(
         }
 
         return try {
-            val event = ProfileBackupEvent.create(signer, vehicles, savedLocations, settings)
+            val event = ProfileBackupEvent.create(signer, vehicles, savedLocations, settings, mutedFollowerPubkeys)
             if (event != null) {
                 relayManager.publish(event)
-                Log.d(TAG, "Published profile backup: ${event.id} (${vehicles.size} vehicles, ${savedLocations.size} locations) to ${relayManager.connectedCount()} relays")
+                Log.d(TAG, "Published profile backup: ${event.id} (${vehicles.size} vehicles, ${savedLocations.size} locations, ${mutedFollowerPubkeys.size} muted) to ${relayManager.connectedCount()} relays")
                 event.id
             } else {
                 Log.e(TAG, "Failed to create profile backup event")

--- a/common/src/main/java/com/ridestr/common/nostr/events/DriverRoadflareStateEvent.kt
+++ b/common/src/main/java/com/ridestr/common/nostr/events/DriverRoadflareStateEvent.kt
@@ -253,13 +253,19 @@ data class DriverRoadflareKey(
  * @param addedAt Timestamp when follower was added
  * @param approved Whether driver has approved this follower (pending if false)
  * @param keyVersionSent Which key version was sent to this follower (0 if not yet sent)
+ * @param mutedAt Lightweight per-follower mute timestamp (issue #80). When non-null, the
+ *   follower is muted: the Kind 3186 send-loop skips delivery and active-follower queries
+ *   exclude them. Distinct from the heavyweight [MutedRider] / "Remove" path which rotates
+ *   the RoadFlare key. Synced cross-device via Kind 30177's `muted_pubkeys` field, NOT via
+ *   Kind 30012 (mute is owned by the profile backup with last-write-wins).
  */
 data class RoadflareFollower(
     val pubkey: String,
     val name: String = "",
     val addedAt: Long,
     val approved: Boolean = false,
-    val keyVersionSent: Int = 0
+    val keyVersionSent: Int = 0,
+    val mutedAt: Long? = null
 ) {
     /**
      * Serialize to JSON.
@@ -271,6 +277,7 @@ data class RoadflareFollower(
             put("addedAt", addedAt)
             put("approved", approved)
             put("keyVersionSent", keyVersionSent)
+            mutedAt?.let { put("mutedAt", it) }
         }
     }
 
@@ -284,7 +291,8 @@ data class RoadflareFollower(
                 name = json.optString("name", ""),
                 addedAt = json.getLong("addedAt"),
                 approved = json.optBoolean("approved", true), // Default true for backwards compat
-                keyVersionSent = json.optInt("keyVersionSent", 0)
+                keyVersionSent = json.optInt("keyVersionSent", 0),
+                mutedAt = if (json.has("mutedAt")) json.getLong("mutedAt") else null
             )
         }
     }

--- a/common/src/main/java/com/ridestr/common/nostr/events/ProfileBackupEvent.kt
+++ b/common/src/main/java/com/ridestr/common/nostr/events/ProfileBackupEvent.kt
@@ -149,13 +149,15 @@ object ProfileBackupEvent {
             }
 
             // Parse muted_pubkeys (issue #80, optional). Missing/empty → no muted pubkeys.
-            // Tolerates non-string entries by skipping them rather than failing the whole parse.
+            // Reject entries that don't look like a 32-byte hex pubkey (64 lowercase hex chars).
+            // `optString` on a numeric JSON entry coerces to e.g. `"42"`, which would otherwise pass
+            // a naive `isNotEmpty` filter and accumulate as junk on every backup republish cycle.
             val mutedFollowerPubkeys = mutableListOf<String>()
             val mutedPubkeysArray = json.optJSONArray("muted_pubkeys")
             if (mutedPubkeysArray != null) {
                 for (i in 0 until mutedPubkeysArray.length()) {
                     val s = mutedPubkeysArray.optString(i, "")
-                    if (s.isNotEmpty()) mutedFollowerPubkeys.add(s)
+                    if (isHexPubkey(s)) mutedFollowerPubkeys.add(s)
                 }
             }
 
@@ -174,6 +176,23 @@ object ProfileBackupEvent {
             null
         }
     }
+
+    /**
+     * True when [s] looks like a 32-byte hex pubkey (64 lowercase hex chars).
+     * Tolerates upper-case input by normalising via [Char.isHexChar]. Used to filter junk
+     * entries from `muted_pubkeys` so a malformed remote event cannot grow the local list
+     * unboundedly across backup cycles.
+     */
+    private fun isHexPubkey(s: String): Boolean {
+        if (s.length != 64) return false
+        for (c in s) {
+            if (!c.isHexChar()) return false
+        }
+        return true
+    }
+
+    private fun Char.isHexChar(): Boolean =
+        (this in '0'..'9') || (this in 'a'..'f') || (this in 'A'..'F')
 }
 
 /**

--- a/common/src/main/java/com/ridestr/common/nostr/events/ProfileBackupEvent.kt
+++ b/common/src/main/java/com/ridestr/common/nostr/events/ProfileBackupEvent.kt
@@ -38,12 +38,18 @@ object ProfileBackupEvent {
      * @param vehicles List of vehicles to backup (driver)
      * @param savedLocations List of saved locations to backup (rider)
      * @param settings Settings to backup
+     * @param mutedFollowerPubkeys Hex pubkeys of RoadFlare followers the driver has lightweight-muted
+     *   (issue #80). Empty for non-driver apps. Cross-device reconciled via last-write-wins on
+     *   the event's `created_at`. Not nested under settings — RoadFlare state, not a
+     *   user-configurable setting. Field is omitted from the JSON when empty so an empty driver or
+     *   any rider produces a wire-identical payload to pre-issue-#80 events.
      */
     suspend fun create(
         signer: NostrSigner,
         vehicles: List<Vehicle>,
         savedLocations: List<SavedLocation>,
-        settings: SettingsBackup
+        settings: SettingsBackup,
+        mutedFollowerPubkeys: List<String> = emptyList()
     ): Event? {
         val pubKeyHex = signer.pubKey
 
@@ -67,6 +73,13 @@ object ProfileBackupEvent {
             put("vehicles", vehiclesArray)
             put("savedLocations", locationsArray)
             put("settings", settingsJson)
+            // muted_pubkeys (issue #80): only emit when non-empty so existing parsers and
+            // rider-only apps produce wire-identical payloads to pre-issue-#80 events.
+            if (mutedFollowerPubkeys.isNotEmpty()) {
+                val mutedPubkeysArray = JSONArray()
+                mutedFollowerPubkeys.forEach { mutedPubkeysArray.put(it) }
+                put("muted_pubkeys", mutedPubkeysArray)
+            }
             put("updated_at", System.currentTimeMillis() / 1000)
         }
 
@@ -135,6 +148,17 @@ object ProfileBackupEvent {
                 SettingsBackup() // Default settings if not present
             }
 
+            // Parse muted_pubkeys (issue #80, optional). Missing/empty → no muted pubkeys.
+            // Tolerates non-string entries by skipping them rather than failing the whole parse.
+            val mutedFollowerPubkeys = mutableListOf<String>()
+            val mutedPubkeysArray = json.optJSONArray("muted_pubkeys")
+            if (mutedPubkeysArray != null) {
+                for (i in 0 until mutedPubkeysArray.length()) {
+                    val s = mutedPubkeysArray.optString(i, "")
+                    if (s.isNotEmpty()) mutedFollowerPubkeys.add(s)
+                }
+            }
+
             val updatedAt = json.getLong("updated_at")
 
             ProfileBackupData(
@@ -142,6 +166,7 @@ object ProfileBackupEvent {
                 vehicles = vehicles,
                 savedLocations = savedLocations,
                 settings = settings,
+                mutedFollowerPubkeys = mutedFollowerPubkeys,
                 updatedAt = updatedAt,
                 createdAt = event.createdAt
             )
@@ -153,12 +178,17 @@ object ProfileBackupEvent {
 
 /**
  * Parsed and decrypted profile backup data.
+ *
+ * @param mutedFollowerPubkeys Hex pubkeys of RoadFlare followers the driver lightweight-muted
+ *   (issue #80). Empty for non-driver backups or pre-issue-#80 events. Drives the last-write-wins
+ *   reconciliation in `RoadflareKeyManager.reconcileMuteStateFromBackup`.
  */
 data class ProfileBackupData(
     val eventId: String,
     val vehicles: List<Vehicle>,
     val savedLocations: List<SavedLocation>,
     val settings: SettingsBackup,
+    val mutedFollowerPubkeys: List<String> = emptyList(),
     val updatedAt: Long,
     val createdAt: Long
 )

--- a/common/src/main/java/com/ridestr/common/nostr/events/ProfileBackupEvent.kt
+++ b/common/src/main/java/com/ridestr/common/nostr/events/ProfileBackupEvent.kt
@@ -149,15 +149,18 @@ object ProfileBackupEvent {
             }
 
             // Parse muted_pubkeys (issue #80, optional). Missing/empty → no muted pubkeys.
-            // Reject entries that don't look like a 32-byte hex pubkey (64 lowercase hex chars).
+            // Reject entries that don't look like a 32-byte hex pubkey (64 hex chars).
             // `optString` on a numeric JSON entry coerces to e.g. `"42"`, which would otherwise pass
             // a naive `isNotEmpty` filter and accumulate as junk on every backup republish cycle.
+            // Normalise to lowercase so equality checks against locally-stored pubkeys (which are
+            // always lowercase via `toHexKey()`) work without case-sensitivity drift across
+            // backup cycles.
             val mutedFollowerPubkeys = mutableListOf<String>()
             val mutedPubkeysArray = json.optJSONArray("muted_pubkeys")
             if (mutedPubkeysArray != null) {
                 for (i in 0 until mutedPubkeysArray.length()) {
                     val s = mutedPubkeysArray.optString(i, "")
-                    if (isHexPubkey(s)) mutedFollowerPubkeys.add(s)
+                    if (isHexPubkey(s)) mutedFollowerPubkeys.add(s.lowercase())
                 }
             }
 
@@ -178,10 +181,14 @@ object ProfileBackupEvent {
     }
 
     /**
-     * True when [s] looks like a 32-byte hex pubkey (64 lowercase hex chars).
-     * Tolerates upper-case input by normalising via [Char.isHexChar]. Used to filter junk
-     * entries from `muted_pubkeys` so a malformed remote event cannot grow the local list
-     * unboundedly across backup cycles.
+     * True when [s] looks like a 32-byte hex pubkey (64 hex chars). The validation is
+     * case-insensitive (accepts both `a–f` and `A–F`); callers that intend to *store* the
+     * value are expected to normalise to lowercase via `s.lowercase()` so equality checks
+     * against locally-emitted pubkeys (which are always lowercase via `toHexKey()`) line up
+     * across backup cycles.
+     *
+     * Used to filter junk entries from `muted_pubkeys` so a malformed remote event cannot
+     * grow the local list unboundedly across backup cycles.
      */
     private fun isHexPubkey(s: String): Boolean {
         if (s.length != 64) return false

--- a/common/src/main/java/com/ridestr/common/roadflare/FollowNotificationResult.kt
+++ b/common/src/main/java/com/ridestr/common/roadflare/FollowNotificationResult.kt
@@ -30,8 +30,8 @@ sealed class FollowNotificationResult {
     object AlreadyPending : FollowNotificationResult()
 
     /**
-     * Rider is on the muted list. No-op — the driver's explicit "Remove"
-     * decision is preserved.
+     * Rider is on the heavyweight muted list ([com.ridestr.common.nostr.events.MutedRider]).
+     * No-op — the driver's explicit "Remove" decision is preserved.
      *
      * Auto-unmuting on Kind 3187 would silently bypass driver consent and
      * conflict with the cross-device sync invariant in
@@ -40,6 +40,18 @@ sealed class FollowNotificationResult {
      * rider the driver re-approves them through the RoadFlare tab.
      */
     object AlreadyMuted : FollowNotificationResult()
+
+    /**
+     * Rider is approved but lightweight-muted (issue #80,
+     * [com.ridestr.common.nostr.events.RoadflareFollower.mutedAt] non-null). No-op —
+     * re-delivering the current Kind 3186 key would defeat the lightweight mute.
+     *
+     * Distinct from [AlreadyMuted] (heavyweight `MutedRider` + key rotation) so the
+     * call site can render different UI / log messages. Recovery: the driver clears
+     * the lightweight mute via the RoadFlare tab's "Unmute" action, which re-sends
+     * the current key.
+     */
+    object AlreadyLightMuted : FollowNotificationResult()
 
     /**
      * Rider was already approved. The current Kind 3186 key share was

--- a/common/src/main/java/com/ridestr/common/roadflare/RoadflareKeyManager.kt
+++ b/common/src/main/java/com/ridestr/common/roadflare/RoadflareKeyManager.kt
@@ -297,6 +297,16 @@ class RoadflareKeyManager(
         }
 
         if (existing.approved) {
+            // Issue #80 — lightweight mute guard. Without this, an approved-but-
+            // lightweight-muted follower who fires a Kind 3187 (re-add after fresh install,
+            // delivery-retry workaround, etc.) would receive a key share, defeating the
+            // lightweight mute. The Kind 3188 ack handler in MainActivity already has the
+            // analogous guard; this is the matching guard for the Kind 3187 path.
+            if (existing.mutedAt != null) {
+                Log.d(TAG, "Skipping resend to lightweight-muted follower ${followerPubkey.take(8)}... (mutedAt=${existing.mutedAt})")
+                return FollowNotificationResult.AlreadyLightMuted
+            }
+
             // Approved re-add — re-deliver the current key. State unchanged, no Kind 30012 republish.
             val hasKey = repository.getRoadflareKey() != null
             val keySent = resendCurrentKey(signer, followerPubkey)
@@ -668,10 +678,20 @@ class RoadflareKeyManager(
 
         // Mark reconciliation as run so subsequent profile-backup publishes can trust the
         // local mute list as authoritative (see DriverRoadflareRepository.isMuteReconciled).
-        // Set unconditionally — even if no changes were applied, we have observed remote and
-        // confirmed local matches. Without this, an auto-backup that fires after reconciliation
-        // would still preserve remote unnecessarily.
-        repository.markMuteReconciled()
+        //
+        // Important: do NOT mark when (followers empty AND remote non-empty). That combination
+        // means we observed remote mutes we couldn't apply (no matching follower row yet — the
+        // Kind 30012 follower-list sync hasn't completed). Marking here would let the next
+        // auto-backup trust the empty local list and silently overwrite the remote `muted_pubkeys`
+        // we just failed to read. The post-sync chained reconciliation in MainActivity will
+        // re-run this method after Kind 30012 sync populates the follower rows; that pass will
+        // observe non-empty followers and mark correctly.
+        val reconciliationWasComplete = followers.isNotEmpty() || remoteSet.isEmpty()
+        if (reconciliationWasComplete) {
+            repository.markMuteReconciled()
+        } else {
+            Log.d(TAG, "reconcileMute: deferring markMuteReconciled — followers list empty but remote has ${remoteSet.size} muted pubkeys (waiting for Kind 30012 sync)")
+        }
 
         return MuteReconciliationResult(muted = muted, unmuted = unmuted, keyResent = keyResent)
     }

--- a/common/src/main/java/com/ridestr/common/roadflare/RoadflareKeyManager.kt
+++ b/common/src/main/java/com/ridestr/common/roadflare/RoadflareKeyManager.kt
@@ -442,4 +442,222 @@ class RoadflareKeyManager(
      * Check if we have an active RoadFlare key.
      */
     fun hasKey(): Boolean = repository.getRoadflareKey() != null
+
+    // ── Lightweight per-follower mute (issue #80) ─────────────────────────────
+    //
+    // Distinct from [handleMuteFollower] / [handleRemoveFollower] which trigger key rotation.
+    // The lightweight mute just suppresses Kind 3186 delivery for one follower, so muting and
+    // unmuting back-to-back has zero side-effect on other followers. Synced cross-device via
+    // Kind 30177's `muted_pubkeys` (last-write-wins on `created_at`); the caller is responsible
+    // for triggering a profile-backup republish after a successful mute/unmute.
+
+    /**
+     * Lightweight-mute a single follower (issue #80).
+     *
+     * Sets `mutedAt` on the follower row. The Kind 3186 send-loop and active-follower
+     * queries skip muted entries. Does NOT rotate the RoadFlare key. Other followers are
+     * untouched.
+     *
+     * Local state takes effect immediately, even when offline. Cross-device sync happens
+     * via the next Kind 30177 publish — the caller (UI handler) should invoke
+     * `profileSyncManager.backupProfileData()` (or equivalent) after this returns true.
+     *
+     * @param followerPubkey Hex pubkey of the follower to mute.
+     * @param now Override the timestamp (epoch seconds). Tests inject a deterministic clock; in
+     *   production the default `System.currentTimeMillis() / 1000` matches the rest of the
+     *   repository's timestamp convention.
+     * @return true if the follower row was updated; false if no matching follower exists.
+     */
+    fun muteFollower(
+        followerPubkey: String,
+        now: Long = System.currentTimeMillis() / 1000
+    ): Boolean {
+        val updated = repository.setFollowerMuted(followerPubkey, now)
+        if (updated) {
+            Log.d(TAG, "Lightweight-muted follower ${followerPubkey.take(8)}... at $now")
+        } else {
+            Log.w(TAG, "muteFollower: no follower row for ${followerPubkey.take(8)}...")
+        }
+        return updated
+    }
+
+    /**
+     * Lightweight-unmute a single follower (issue #80).
+     *
+     * Clears `mutedAt` on the follower row and best-effort re-delivers the current RoadFlare
+     * key via Kind 3186 so the rider can resume decrypting location broadcasts. Does NOT
+     * rotate the key. The caller should trigger a profile-backup republish afterward.
+     *
+     * @param signer The driver's identity signer for publishing the Kind 3186 key share.
+     * @param followerPubkey Hex pubkey of the follower to unmute.
+     * @return true if the follower row was updated. The Kind 3186 send is best-effort and
+     *   does not affect this return value (a transient relay failure is recoverable on next
+     *   `ensureFollowersHaveCurrentKey`).
+     */
+    suspend fun unmuteFollower(
+        signer: NostrSigner,
+        followerPubkey: String
+    ): Boolean {
+        val updated = repository.setFollowerUnmuted(followerPubkey)
+        if (!updated) {
+            Log.w(TAG, "unmuteFollower: no follower row for ${followerPubkey.take(8)}...")
+            return false
+        }
+
+        Log.d(TAG, "Lightweight-unmuted follower ${followerPubkey.take(8)}...")
+
+        // Best-effort key re-delivery so the unmuted rider can decrypt new broadcasts.
+        // No key rotation; uses the current key + keyUpdatedAt verbatim.
+        val key = repository.getRoadflareKey()
+        val keyUpdatedAt = repository.getKeyUpdatedAt() ?: key?.createdAt
+        if (key != null && keyUpdatedAt != null) {
+            val sent = sendKeyToFollower(signer, followerPubkey, key, keyUpdatedAt)
+            if (sent) {
+                repository.markFollowerKeySent(followerPubkey, key.version)
+            } else {
+                Log.w(TAG, "unmuteFollower: Kind 3186 re-delivery failed for ${followerPubkey.take(8)}... (recoverable)")
+            }
+        } else {
+            Log.w(TAG, "unmuteFollower: no current key to re-deliver to ${followerPubkey.take(8)}...")
+        }
+
+        return true
+    }
+
+    /**
+     * Fetch the driver's own Kind 30177 profile backup and apply mute reconciliation.
+     *
+     * Convenience wrapper around [reconcileMuteStateFromBackup] for the app-start path: the
+     * driver app calls this after Kind 30012 sync (which populates the follower list).
+     * Returns null when no backup exists or the fetch fails — the caller can treat that as
+     * "no remote state, nothing to reconcile" and continue with current local state.
+     *
+     * Does NOT trigger a profile-backup republish on its own. The caller decides whether to
+     * publish based on [MuteReconciliationResult.changed]; the existing `backupProfileData()`
+     * pipeline picks up the merged state via the [com.ridestr.common.sync.ProfileSyncAdapter]
+     * → driver-roadflare-repository wiring.
+     *
+     * @return Reconciliation result, or null if no Kind 30177 backup was found / fetch failed.
+     */
+    suspend fun fetchAndReconcileMuteFromBackup(signer: NostrSigner): MuteReconciliationResult? {
+        val backup = try {
+            nostrService.fetchProfileBackup()
+        } catch (e: Exception) {
+            Log.w(TAG, "fetchAndReconcileMute: profile backup fetch threw — skipping", e)
+            return null
+        }
+        if (backup == null) {
+            Log.d(TAG, "fetchAndReconcileMute: no Kind 30177 backup found — nothing to reconcile")
+            return null
+        }
+        return reconcileMuteStateFromBackup(
+            signer = signer,
+            remoteMutedPubkeys = backup.mutedFollowerPubkeys,
+            remoteCreatedAt = backup.createdAt
+        )
+    }
+
+    /**
+     * Reconcile the local lightweight-mute state against a remote Kind 30177 backup
+     * using last-write-wins on `created_at` (issue #80).
+     *
+     * Per-pubkey rules:
+     * - Pubkey in remote `muted_pubkeys`, not muted locally → mute locally with `mutedAt =
+     *   remoteCreatedAt`. Backup is treated as the authoritative timestamp for that mute.
+     * - Pubkey muted locally, also in remote → no-op (already muted; preserve original local
+     *   `mutedAt`).
+     * - Pubkey muted locally, NOT in remote, `local.mutedAt > remoteCreatedAt` → keep local
+     *   mute (newer than remote backup; next publish will sync).
+     * - Pubkey muted locally, NOT in remote, `local.mutedAt <= remoteCreatedAt` → unmute
+     *   locally and best-effort re-deliver Kind 3186 (remote backup wrote the unmute after our
+     *   mute).
+     *
+     * Pubkeys present only as remote-muted but unknown to the local follower list are skipped:
+     * we cannot mute a row that does not exist. They will resolve naturally if/when the
+     * follower is re-added via Kind 3187.
+     *
+     * Idempotent: running it again with the same inputs makes no further mutations.
+     *
+     * @param signer Driver's identity signer for publishing the unmute Kind 3186 events.
+     * @param remoteMutedPubkeys The `muted_pubkeys` array from the remote Kind 30177 payload.
+     * @param remoteCreatedAt The `created_at` timestamp of the remote Kind 30177 event (epoch seconds).
+     * @return Counts of state changes applied. Caller can use these to decide whether to
+     *   republish a Kind 30177 reflecting the merged local state.
+     */
+    suspend fun reconcileMuteStateFromBackup(
+        signer: NostrSigner,
+        remoteMutedPubkeys: List<String>,
+        remoteCreatedAt: Long
+    ): MuteReconciliationResult {
+        val followers = repository.getFollowers()
+        val remoteSet = remoteMutedPubkeys.toSet()
+
+        var muted = 0
+        var unmuted = 0
+        var keyResent = 0
+
+        // Case A: pubkey in remote backup → ensure local is muted.
+        for (pubkey in remoteSet) {
+            val local = followers.find { it.pubkey == pubkey }
+            if (local == null) {
+                Log.d(TAG, "reconcileMute: skipping unknown pubkey ${pubkey.take(8)}... (not in followers)")
+                continue
+            }
+            if (local.mutedAt == null) {
+                if (repository.setFollowerMuted(pubkey, remoteCreatedAt)) {
+                    muted++
+                    Log.d(TAG, "reconcileMute: muted ${pubkey.take(8)}... locally (backup wins, mutedAt=$remoteCreatedAt)")
+                }
+            }
+        }
+
+        // Case B: pubkey muted locally, NOT in remote backup → last-write-wins on local.mutedAt vs remoteCreatedAt.
+        for (follower in followers) {
+            val localMutedAt = follower.mutedAt ?: continue
+            if (follower.pubkey in remoteSet) continue
+
+            if (localMutedAt > remoteCreatedAt) {
+                // Local mute is newer than the backup; keep local. Next publish syncs out.
+                Log.d(TAG, "reconcileMute: kept local mute on ${follower.pubkey.take(8)}... (local=$localMutedAt > remote=$remoteCreatedAt)")
+            } else {
+                // Backup is newer and doesn't include this pubkey → remote unmuted it.
+                if (repository.setFollowerUnmuted(follower.pubkey)) {
+                    unmuted++
+                    Log.d(TAG, "reconcileMute: unmuted ${follower.pubkey.take(8)}... (remote=$remoteCreatedAt >= local=$localMutedAt)")
+
+                    // Best-effort key re-delivery so the rider can resume decrypting.
+                    val key = repository.getRoadflareKey()
+                    val keyUpdatedAt = repository.getKeyUpdatedAt() ?: key?.createdAt
+                    if (key != null && keyUpdatedAt != null) {
+                        if (sendKeyToFollower(signer, follower.pubkey, key, keyUpdatedAt)) {
+                            repository.markFollowerKeySent(follower.pubkey, key.version)
+                            keyResent++
+                        }
+                    }
+                }
+            }
+        }
+
+        if (muted > 0 || unmuted > 0) {
+            Log.d(TAG, "reconcileMute: muted=$muted, unmuted=$unmuted, keyResent=$keyResent")
+        }
+
+        return MuteReconciliationResult(muted = muted, unmuted = unmuted, keyResent = keyResent)
+    }
+}
+
+/**
+ * Aggregate result of [RoadflareKeyManager.reconcileMuteStateFromBackup].
+ *
+ * @param muted Number of followers newly muted by this reconciliation pass (remote → local).
+ * @param unmuted Number of followers newly unmuted by this pass (remote → local).
+ * @param keyResent Number of Kind 3186 re-deliveries triggered by an unmute.
+ */
+data class MuteReconciliationResult(
+    val muted: Int,
+    val unmuted: Int,
+    val keyResent: Int
+) {
+    /** True when the reconciliation produced at least one local state change. */
+    val changed: Boolean get() = muted > 0 || unmuted > 0
 }

--- a/common/src/main/java/com/ridestr/common/roadflare/RoadflareKeyManager.kt
+++ b/common/src/main/java/com/ridestr/common/roadflare/RoadflareKeyManager.kt
@@ -508,9 +508,18 @@ class RoadflareKeyManager(
 
         // Best-effort key re-delivery so the unmuted rider can decrypt new broadcasts.
         // No key rotation; uses the current key + keyUpdatedAt verbatim.
+        //
+        // If `getKeyUpdatedAt()` is null, persist the `key.createdAt` fallback via
+        // `updateKeyUpdatedAt` — same write-back pattern PR #79 added to `resendCurrentKey`.
+        // Without this, the next `publishDriverRoadflareState` would fall through to
+        // `DriverRoadflareStateEvent.create`'s wall-clock fallback and silently advance the
+        // public `key_updated_at` tag, invalidating riders' stored keys.
         val key = repository.getRoadflareKey()
-        val keyUpdatedAt = repository.getKeyUpdatedAt() ?: key?.createdAt
-        if (key != null && keyUpdatedAt != null) {
+        if (key != null) {
+            val keyUpdatedAt = repository.getKeyUpdatedAt() ?: run {
+                repository.updateKeyUpdatedAt(key.createdAt)
+                key.createdAt
+            }
             val sent = sendKeyToFollower(signer, followerPubkey, key, keyUpdatedAt)
             if (sent) {
                 repository.markFollowerKeySent(followerPubkey, key.version)
@@ -621,17 +630,32 @@ class RoadflareKeyManager(
                 Log.d(TAG, "reconcileMute: kept local mute on ${follower.pubkey.take(8)}... (local=$localMutedAt > remote=$remoteCreatedAt)")
             } else {
                 // Backup is newer and doesn't include this pubkey → remote unmuted it.
+                // BUT: if the rider was meanwhile heavyweight-muted ("Removed") on another device,
+                // the key has been rotated and they MUST stay excluded. Clear our local lightweight
+                // mute (so the state stays consistent with the remote backup) but skip the Kind 3186
+                // re-delivery — sending the post-rotation key would defeat the heavyweight mute.
+                val isHeavyweightMuted = repository.isMuted(follower.pubkey)
                 if (repository.setFollowerUnmuted(follower.pubkey)) {
                     unmuted++
                     Log.d(TAG, "reconcileMute: unmuted ${follower.pubkey.take(8)}... (remote=$remoteCreatedAt >= local=$localMutedAt)")
 
-                    // Best-effort key re-delivery so the rider can resume decrypting.
-                    val key = repository.getRoadflareKey()
-                    val keyUpdatedAt = repository.getKeyUpdatedAt() ?: key?.createdAt
-                    if (key != null && keyUpdatedAt != null) {
-                        if (sendKeyToFollower(signer, follower.pubkey, key, keyUpdatedAt)) {
-                            repository.markFollowerKeySent(follower.pubkey, key.version)
-                            keyResent++
+                    if (isHeavyweightMuted) {
+                        Log.d(TAG, "reconcileMute: skipping Kind 3186 re-delivery to ${follower.pubkey.take(8)}... — heavyweight-muted (Removed) on another device")
+                    } else {
+                        // Best-effort key re-delivery so the rider can resume decrypting.
+                        // Mirror PR #79's `resendCurrentKey` write-back so the null-fallback for
+                        // `keyUpdatedAt` is persisted and a future Kind 30012 publish doesn't
+                        // wall-clock-advance the public `key_updated_at` tag.
+                        val key = repository.getRoadflareKey()
+                        if (key != null) {
+                            val keyUpdatedAt = repository.getKeyUpdatedAt() ?: run {
+                                repository.updateKeyUpdatedAt(key.createdAt)
+                                key.createdAt
+                            }
+                            if (sendKeyToFollower(signer, follower.pubkey, key, keyUpdatedAt)) {
+                                repository.markFollowerKeySent(follower.pubkey, key.version)
+                                keyResent++
+                            }
                         }
                     }
                 }

--- a/common/src/main/java/com/ridestr/common/roadflare/RoadflareKeyManager.kt
+++ b/common/src/main/java/com/ridestr/common/roadflare/RoadflareKeyManager.kt
@@ -666,6 +666,13 @@ class RoadflareKeyManager(
             Log.d(TAG, "reconcileMute: muted=$muted, unmuted=$unmuted, keyResent=$keyResent")
         }
 
+        // Mark reconciliation as run so subsequent profile-backup publishes can trust the
+        // local mute list as authoritative (see DriverRoadflareRepository.isMuteReconciled).
+        // Set unconditionally — even if no changes were applied, we have observed remote and
+        // confirmed local matches. Without this, an auto-backup that fires after reconciliation
+        // would still preserve remote unnecessarily.
+        repository.markMuteReconciled()
+
         return MuteReconciliationResult(muted = muted, unmuted = unmuted, keyResent = keyResent)
     }
 }

--- a/common/src/main/java/com/ridestr/common/sync/ProfileSyncAdapter.kt
+++ b/common/src/main/java/com/ridestr/common/sync/ProfileSyncAdapter.kt
@@ -1,6 +1,7 @@
 package com.ridestr.common.sync
 
 import android.util.Log
+import com.ridestr.common.data.DriverRoadflareRepository
 import com.ridestr.common.data.SavedLocation
 import com.ridestr.common.data.SavedLocationRepository
 import com.ridestr.common.data.Vehicle
@@ -27,12 +28,21 @@ import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
  *
  * Migration: On fetch, if no 30177 event found, falls back to separate
  * 30175 (vehicles) and 30176 (locations) events for backward compatibility.
+ *
+ * @param driverRoadflareRepository Optional driver-only repository whose lightweight-mute state
+ *   (issue #80, [DriverRoadflareRepository.getMutedFollowerPubkeys]) is published in the
+ *   `muted_pubkeys` field of Kind 30177. Null for rider apps; the field is then omitted from
+ *   the wire payload entirely. Restoration of mute state is NOT done here — it requires the
+ *   follower list (synced via Kind 30012) to already be present, so the driver app calls
+ *   [com.ridestr.common.roadflare.RoadflareKeyManager.reconcileMuteStateFromBackup] explicitly
+ *   after both sync passes complete.
  */
 class ProfileSyncAdapter(
     private val vehicleRepository: VehicleRepository?,
     private val savedLocationRepository: SavedLocationRepository?,
     private val settingsRepository: SettingsRepository,
-    private val nostrService: NostrService
+    private val nostrService: NostrService,
+    private val driverRoadflareRepository: DriverRoadflareRepository? = null
 ) : SyncableProfileData {
 
     companion object {
@@ -190,9 +200,16 @@ class ProfileSyncAdapter(
                 ?: emptyList()
             val settings = settingsRepository.toBackupData()
 
-            val eventId = nostrService.publishProfileBackup(vehicles, savedLocations, settings)
+            // muted_pubkeys (issue #80): driver-only. When the driver repository is absent
+            // (rider apps), preserve whatever was in the existing remote backup so we don't
+            // accidentally drop a sibling driver app's mute state from the same identity.
+            val mutedFollowerPubkeys = driverRoadflareRepository?.getMutedFollowerPubkeys()
+                ?: existingProfile?.mutedFollowerPubkeys
+                ?: emptyList()
+
+            val eventId = nostrService.publishProfileBackup(vehicles, savedLocations, settings, mutedFollowerPubkeys)
             if (eventId != null) {
-                Log.d(TAG, "Profile backed up as event $eventId (${vehicles.size} vehicles, ${savedLocations.size} locations)")
+                Log.d(TAG, "Profile backed up as event $eventId (${vehicles.size} vehicles, ${savedLocations.size} locations, ${mutedFollowerPubkeys.size} muted)")
             } else {
                 Log.w(TAG, "Failed to backup profile")
             }

--- a/common/src/main/java/com/ridestr/common/sync/ProfileSyncAdapter.kt
+++ b/common/src/main/java/com/ridestr/common/sync/ProfileSyncAdapter.kt
@@ -200,12 +200,26 @@ class ProfileSyncAdapter(
                 ?: emptyList()
             val settings = settingsRepository.toBackupData()
 
-            // muted_pubkeys (issue #80): driver-only. When the driver repository is absent
-            // (rider apps), preserve whatever was in the existing remote backup so we don't
-            // accidentally drop a sibling driver app's mute state from the same identity.
-            val mutedFollowerPubkeys = driverRoadflareRepository?.getMutedFollowerPubkeys()
-                ?: existingProfile?.mutedFollowerPubkeys
-                ?: emptyList()
+            // muted_pubkeys (issue #80): driver-only.
+            //
+            // Three-way decision:
+            // - Rider app (no driverRoadflareRepository) → preserve remote so we don't drop
+            //   a sibling driver app's mute state from the same identity.
+            // - Driver app, reconciliation has NOT yet run this session → preserve remote.
+            //   Local mute list may be empty only because Kind 30012 sync + Kind 30177
+            //   reconciliation haven't completed yet (fresh device first key-import).
+            //   Trusting an empty local list here would silently wipe cross-device mutes
+            //   before reconciliation observes them.
+            // - Driver app, reconciliation HAS run → trust local. An empty local list now
+            //   reflects "user unmuted everyone" — a deliberate empty publish.
+            val mutedFollowerPubkeys = when {
+                driverRoadflareRepository == null ->
+                    existingProfile?.mutedFollowerPubkeys ?: emptyList()
+                driverRoadflareRepository.isMuteReconciled() ->
+                    driverRoadflareRepository.getMutedFollowerPubkeys()
+                else ->
+                    existingProfile?.mutedFollowerPubkeys ?: emptyList()
+            }
 
             val eventId = nostrService.publishProfileBackup(vehicles, savedLocations, settings, mutedFollowerPubkeys)
             if (eventId != null) {

--- a/common/src/test/java/com/ridestr/common/coordinator/RoadflareDriverCoordinatorMergeTest.kt
+++ b/common/src/test/java/com/ridestr/common/coordinator/RoadflareDriverCoordinatorMergeTest.kt
@@ -39,13 +39,15 @@ class RoadflareDriverCoordinatorMergeTest {
         pubkey: String,
         approved: Boolean = false,
         keyVersionSent: Int = 0,
-        addedAt: Long = 1_000L
+        addedAt: Long = 1_000L,
+        mutedAt: Long? = null
     ) = RoadflareFollower(
         pubkey = pubkey,
         name = "",
         addedAt = addedAt,
         approved = approved,
-        keyVersionSent = keyVersionSent
+        keyVersionSent = keyVersionSent,
+        mutedAt = mutedAt
     )
 
     // ── mergeFollowerLists ────────────────────────────────────────────────────
@@ -190,5 +192,60 @@ class RoadflareDriverCoordinatorMergeTest {
 
         assertEquals(1, merged.size)
         assertEquals("A", merged[0].pubkey)
+    }
+
+    // ── Lightweight mute (issue #80) — mutedAt union-merge ───────────────────
+
+    @Test
+    fun `mergeFollowerLists takes remote mutedAt when local lacks it`() {
+        // Cross-device scenario: device 1 lightweight-mutes follower A and republishes Kind 30012.
+        // Device 2 (no local mute) syncs. The pre-fix code did `existing.copy(approved=...,
+        // keyVersionSent=..., addedAt=...)` and silently dropped remote.mutedAt because the
+        // copy preserved local's null. The union-merge fix means the remote mute survives.
+        val local = listOf(follower("A", mutedAt = null))
+        val remote = listOf(follower("A", mutedAt = 1_500L))
+
+        val merged = coordinator.mergeFollowerLists(local, remote, 1, 100L, 100L)
+
+        assertEquals(1, merged.size)
+        assertEquals("remote mutedAt must propagate when local lacks it", 1_500L, merged[0].mutedAt)
+    }
+
+    @Test
+    fun `mergeFollowerLists keeps local mutedAt when remote lacks it`() {
+        // Inverse: local has the mute, remote doesn't (e.g., remote backup is stale).
+        // Local mute must survive the merge.
+        val local = listOf(follower("A", mutedAt = 1_500L))
+        val remote = listOf(follower("A", mutedAt = null))
+
+        val merged = coordinator.mergeFollowerLists(local, remote, 1, 100L, 100L)
+
+        assertEquals(1, merged.size)
+        assertEquals(1_500L, merged[0].mutedAt)
+    }
+
+    @Test
+    fun `mergeFollowerLists picks earliest mutedAt when both sides have it`() {
+        // Two devices independently muted the same follower at different times.
+        // The earlier timestamp wins (preserves the original mute moment).
+        val local = listOf(follower("A", mutedAt = 2_000L))
+        val remote = listOf(follower("A", mutedAt = 1_500L))
+
+        val merged = coordinator.mergeFollowerLists(local, remote, 1, 100L, 100L)
+
+        assertEquals(1, merged.size)
+        assertEquals("earlier of the two mutedAt timestamps wins", 1_500L, merged[0].mutedAt)
+    }
+
+    @Test
+    fun `mergeFollowerLists preserves null mutedAt when neither side has it`() {
+        // No regression: a normal merge of two unmuted entries keeps mutedAt null.
+        val local = listOf(follower("A", approved = true, mutedAt = null))
+        val remote = listOf(follower("A", approved = true, mutedAt = null))
+
+        val merged = coordinator.mergeFollowerLists(local, remote, 1, 100L, 100L)
+
+        assertEquals(1, merged.size)
+        assertNull(merged[0].mutedAt)
     }
 }

--- a/common/src/test/java/com/ridestr/common/nostr/events/ProfileBackupEventMutedPubkeysTest.kt
+++ b/common/src/test/java/com/ridestr/common/nostr/events/ProfileBackupEventMutedPubkeysTest.kt
@@ -173,10 +173,15 @@ class ProfileBackupEventMutedPubkeysTest {
         val parsed = ProfileBackupEvent.parseAndDecrypt(signer, event)
         assertNotNull(parsed)
         val muted = parsed!!.mutedFollowerPubkeys
-        // Valid entries survive (lower- and upper-case hex both accepted).
+        // Valid entries survive (lower-case stored as-is).
         assertTrue("expected valid lower-hex c…", muted.contains("c".repeat(64)))
         assertTrue("expected valid lower-hex d…", muted.contains("d".repeat(64)))
-        assertTrue("expected upper-case hex accepted", muted.contains("AABBCCDDEEFFAABBCCDDEEFFAABBCCDDEEFFAABBCCDDEEFFAABBCCDDEEFFAABB"))
+        // Upper-case hex is accepted by validation but NORMALISED to lowercase on storage so
+        // equality checks against `RoadflareFollower.pubkey` (always lowercase via toHexKey())
+        // line up across backup cycles. Without normalisation, an upper-case entry from a
+        // malformed remote event would silently drop on the next publish cycle.
+        assertFalse("upper-case hex must NOT round-trip in upper-case", muted.contains("AABBCCDDEEFFAABBCCDDEEFFAABBCCDDEEFFAABBCCDDEEFFAABBCCDDEEFFAABB"))
+        assertTrue("upper-case hex must be normalised to lowercase on storage", muted.contains("aabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabb"))
         // Junk entries are rejected.
         assertFalse("numeric '42' must NOT pass the hex filter", muted.contains("42"))
         assertFalse("63-char entry must NOT pass length check", muted.contains("a".repeat(63)))

--- a/common/src/test/java/com/ridestr/common/nostr/events/ProfileBackupEventMutedPubkeysTest.kt
+++ b/common/src/test/java/com/ridestr/common/nostr/events/ProfileBackupEventMutedPubkeysTest.kt
@@ -8,6 +8,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -137,17 +138,24 @@ class ProfileBackupEventMutedPubkeysTest {
     }
 
     @Test
-    fun `parseAndDecrypt tolerates non-string entries in muted_pubkeys array`() = runTest {
+    fun `parseAndDecrypt rejects non-hex and wrong-length entries in muted_pubkeys array`() = runTest {
+        // The parser must filter junk entries (numbers, short strings, non-hex chars) so a
+        // malformed remote event cannot grow the local mute list unboundedly across backup
+        // cycles. Only canonical 32-byte hex pubkeys (64 lowercase hex chars) are accepted.
         val signer = identitySigner()
         val payload = JSONObject().apply {
             put("vehicles", org.json.JSONArray())
             put("savedLocations", org.json.JSONArray())
             put("settings", SettingsBackup().toJson())
-            // Mix in a numeric junk entry — should be skipped, not crash.
             put("muted_pubkeys", org.json.JSONArray().apply {
-                put("c".repeat(64))
-                put(42)
-                put("d".repeat(64))
+                put("c".repeat(64))                  // valid hex
+                put(42)                              // numeric — coerced to "42" by optString
+                put("d".repeat(64))                  // valid hex
+                put("not-hex-but-64-chars-long-______________________________________") // 64 chars, non-hex
+                put("a".repeat(63))                  // wrong length (off-by-one short)
+                put("a".repeat(65))                  // wrong length (off-by-one long)
+                put("")                              // empty
+                put("AABBCCDDEEFFAABBCCDDEEFFAABBCCDDEEFFAABBCCDDEEFFAABBCCDDEEFFAABB") // upper-case hex (accepted)
             })
             put("updated_at", 1L)
         }.toString()
@@ -164,11 +172,16 @@ class ProfileBackupEventMutedPubkeysTest {
 
         val parsed = ProfileBackupEvent.parseAndDecrypt(signer, event)
         assertNotNull(parsed)
-        // Numeric entry "42" is coerced by optString; we only really care that no crash and
-        // valid hex strings survive. The implementation skips entries that optString returns
-        // as empty (none here), so the numeric coerces to "42" and gets included. Either way
-        // the test pins the no-crash behavior.
-        assertTrue(parsed!!.mutedFollowerPubkeys.contains("c".repeat(64)))
-        assertTrue(parsed.mutedFollowerPubkeys.contains("d".repeat(64)))
+        val muted = parsed!!.mutedFollowerPubkeys
+        // Valid entries survive (lower- and upper-case hex both accepted).
+        assertTrue("expected valid lower-hex c…", muted.contains("c".repeat(64)))
+        assertTrue("expected valid lower-hex d…", muted.contains("d".repeat(64)))
+        assertTrue("expected upper-case hex accepted", muted.contains("AABBCCDDEEFFAABBCCDDEEFFAABBCCDDEEFFAABBCCDDEEFFAABBCCDDEEFFAABB"))
+        // Junk entries are rejected.
+        assertFalse("numeric '42' must NOT pass the hex filter", muted.contains("42"))
+        assertFalse("63-char entry must NOT pass length check", muted.contains("a".repeat(63)))
+        assertFalse("65-char entry must NOT pass length check", muted.contains("a".repeat(65)))
+        assertFalse("empty string must NOT pass length check", muted.contains(""))
+        assertEquals("only the 3 valid entries survive", 3, muted.size)
     }
 }

--- a/common/src/test/java/com/ridestr/common/nostr/events/ProfileBackupEventMutedPubkeysTest.kt
+++ b/common/src/test/java/com/ridestr/common/nostr/events/ProfileBackupEventMutedPubkeysTest.kt
@@ -1,0 +1,174 @@
+package com.ridestr.common.nostr.events
+
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.json.JSONObject
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Schema-level tests for issue #80's `muted_pubkeys` field on Kind 30177.
+ *
+ * The encryption layer is mocked to identity (encrypt(x, _) → x, decrypt(x, _) → x) so the
+ * tests exercise the JSON serialization / parsing without needing a real NIP-44 implementation.
+ *
+ * Robolectric is required because `org.json.JSONObject` ships as part of the Android runtime
+ * (a stub-only class on the host JVM) — without Robolectric it throws "not mocked".
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class ProfileBackupEventMutedPubkeysTest {
+
+    private val pubKey = "deadbeef".repeat(8)
+
+    /**
+     * Build a signer mock whose `nip44Encrypt`/`nip44Decrypt` are identity functions,
+     * and whose `sign<Event>` returns an Event with the supplied content / kind / pubKey.
+     * Lets us inspect the JSON payload that would be encrypted, then parse it back through
+     * the real `parseAndDecrypt` path.
+     */
+    private fun identitySigner(): NostrSigner {
+        val signer = mockk<NostrSigner>(relaxed = true)
+        every { signer.pubKey } returns pubKey
+        coEvery { signer.nip44Encrypt(any(), any()) } answers { firstArg() }
+        coEvery { signer.nip44Decrypt(any(), any()) } answers { firstArg() }
+
+        // sign<Event>: emit a minimal Event capturing the content + kind we care about.
+        coEvery {
+            signer.sign<Event>(any(), any(), any(), any())
+        } answers {
+            val createdAt = firstArg<Long>()
+            val kind = secondArg<Int>()
+            val tags = thirdArg<Array<Array<String>>>()
+            val content = arg<String>(3)
+            Event(
+                id = "test-event-id",
+                pubKey = pubKey,
+                createdAt = createdAt,
+                kind = kind,
+                tags = tags,
+                content = content,
+                sig = "sig"
+            )
+        }
+        return signer
+    }
+
+    // ── Acceptance criterion 5: missing muted_pubkeys parses gracefully ───────
+
+    @Test
+    fun `parseAndDecrypt yields empty mutedFollowerPubkeys when field absent`() = runTest {
+        val signer = identitySigner()
+
+        // Hand-build a payload that intentionally omits `muted_pubkeys` — mimics events
+        // produced before issue #80 shipped. `parseAndDecrypt` must default the field to
+        // an empty list rather than throwing.
+        val plaintext = JSONObject().apply {
+            put("vehicles", org.json.JSONArray())
+            put("savedLocations", org.json.JSONArray())
+            put("settings", SettingsBackup().toJson())
+            put("updated_at", 12_345L)
+        }.toString()
+
+        val event = Event(
+            id = "evt-no-mute",
+            pubKey = pubKey,
+            createdAt = 1_000L,
+            kind = RideshareEventKinds.PROFILE_BACKUP,
+            tags = arrayOf(arrayOf("d", ProfileBackupEvent.D_TAG)),
+            content = plaintext,
+            sig = "sig"
+        )
+
+        val parsed = ProfileBackupEvent.parseAndDecrypt(signer, event)
+        assertNotNull(parsed)
+        assertTrue("expected empty mutedFollowerPubkeys when field absent", parsed!!.mutedFollowerPubkeys.isEmpty())
+    }
+
+    @Test
+    fun `parseAndDecrypt round-trips muted_pubkeys field`() = runTest {
+        val signer = identitySigner()
+        val muted = listOf("a".repeat(64), "b".repeat(64))
+
+        val event = ProfileBackupEvent.create(
+            signer = signer,
+            vehicles = emptyList(),
+            savedLocations = emptyList(),
+            settings = SettingsBackup(),
+            mutedFollowerPubkeys = muted
+        )!!
+
+        val parsed = ProfileBackupEvent.parseAndDecrypt(signer, event)
+        assertNotNull(parsed)
+        assertEquals(muted, parsed!!.mutedFollowerPubkeys)
+    }
+
+    @Test
+    fun `create omits muted_pubkeys field entirely when list is empty`() = runTest {
+        // Wire-format invariant: rider apps and pre-#80 driver flows must produce identical
+        // payloads. The `muted_pubkeys` key MUST NOT appear in the JSON when the list is empty.
+        val signer = identitySigner()
+        val captured = slot<String>()
+        coEvery { signer.nip44Encrypt(capture(captured), any()) } answers { firstArg() }
+
+        ProfileBackupEvent.create(
+            signer = signer,
+            vehicles = emptyList(),
+            savedLocations = emptyList(),
+            settings = SettingsBackup(),
+            mutedFollowerPubkeys = emptyList()
+        )
+
+        val json = JSONObject(captured.captured)
+        assertTrue(
+            "muted_pubkeys should NOT appear in payload when list is empty (wire-compat)",
+            !json.has("muted_pubkeys")
+        )
+    }
+
+    @Test
+    fun `parseAndDecrypt tolerates non-string entries in muted_pubkeys array`() = runTest {
+        val signer = identitySigner()
+        val payload = JSONObject().apply {
+            put("vehicles", org.json.JSONArray())
+            put("savedLocations", org.json.JSONArray())
+            put("settings", SettingsBackup().toJson())
+            // Mix in a numeric junk entry — should be skipped, not crash.
+            put("muted_pubkeys", org.json.JSONArray().apply {
+                put("c".repeat(64))
+                put(42)
+                put("d".repeat(64))
+            })
+            put("updated_at", 1L)
+        }.toString()
+
+        val event = Event(
+            id = "evt-mixed",
+            pubKey = pubKey,
+            createdAt = 1L,
+            kind = RideshareEventKinds.PROFILE_BACKUP,
+            tags = arrayOf(arrayOf("d", ProfileBackupEvent.D_TAG)),
+            content = payload,
+            sig = "sig"
+        )
+
+        val parsed = ProfileBackupEvent.parseAndDecrypt(signer, event)
+        assertNotNull(parsed)
+        // Numeric entry "42" is coerced by optString; we only really care that no crash and
+        // valid hex strings survive. The implementation skips entries that optString returns
+        // as empty (none here), so the numeric coerces to "42" and gets included. Either way
+        // the test pins the no-crash behavior.
+        assertTrue(parsed!!.mutedFollowerPubkeys.contains("c".repeat(64)))
+        assertTrue(parsed.mutedFollowerPubkeys.contains("d".repeat(64)))
+    }
+}

--- a/common/src/test/java/com/ridestr/common/roadflare/RoadflareMuteTest.kt
+++ b/common/src/test/java/com/ridestr/common/roadflare/RoadflareMuteTest.kt
@@ -427,6 +427,39 @@ class RoadflareMuteTest {
     }
 
     @Test
+    fun `isMuteReconciled flips false to true after reconcileMuteStateFromBackup runs`() = runTest {
+        // Pass 3 fix: ProfileSyncAdapter.publishToNostr uses this gate to decide whether to
+        // trust an empty local mute list (after reconciliation) or preserve remote (before).
+        // Without the gate, an auto-backup that fires before reconciliation would silently wipe
+        // remote `muted_pubkeys` on a freshly imported device.
+        assertFalse("flag should start false on a fresh repository", repository.isMuteReconciled())
+
+        keyManager.reconcileMuteStateFromBackup(
+            signer = signer,
+            remoteMutedPubkeys = emptyList(),
+            remoteCreatedAt = 1_000L
+        )
+
+        assertTrue("flag should flip true even when reconcile makes no changes", repository.isMuteReconciled())
+    }
+
+    @Test
+    fun `isMuteReconciled flips true even when reconcile applies no changes`() = runTest {
+        // The flag is independent of changed — what matters is that we observed the remote
+        // and confirmed local matches.
+        seedFollower("rider-A", mutedAt = null)
+
+        val result = keyManager.reconcileMuteStateFromBackup(
+            signer = signer,
+            remoteMutedPubkeys = emptyList(),
+            remoteCreatedAt = 1_000L
+        )
+
+        assertFalse(result.changed)
+        assertTrue(repository.isMuteReconciled())
+    }
+
+    @Test
     fun `reconcile unmute does NOT re-deliver key when rider is heavyweight-muted`() = runTest {
         // Cross-device hazard: device 1 lightweight-mutes a rider; device 2 then "Removes" them
         // (handleMuteFollower → muteRider + rotateKey). If device 2's Kind 30177 is older than

--- a/common/src/test/java/com/ridestr/common/roadflare/RoadflareMuteTest.kt
+++ b/common/src/test/java/com/ridestr/common/roadflare/RoadflareMuteTest.kt
@@ -7,6 +7,7 @@ import com.ridestr.common.nostr.events.DriverRoadflareKey
 import com.ridestr.common.nostr.events.MutedRider
 import com.ridestr.common.nostr.events.RoadflareFollower
 import com.ridestr.common.nostr.events.RoadflareKey
+import com.ridestr.common.roadflare.FollowNotificationResult
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -382,6 +383,90 @@ class RoadflareMuteTest {
         // Callers can still trigger republish; reconciliation doesn't rely on the boolean.
         seedFollower("rider-A", mutedAt = null)
         assertTrue(repository.setFollowerUnmuted("rider-A"))
+    }
+
+    // ── Post-rebase pass: cross-PR seam fixes (PR #79 + PR #81) ───────────────
+
+    @Test
+    fun `handleFollowNotification returns AlreadyLightMuted for approved lightweight-muted follower`() = runTest {
+        // PR #79's handleFollowNotification only checked the heavyweight MutedRider list.
+        // After rebasing PR #81 onto post-#79 main, an approved lightweight-muted follower
+        // (mutedAt != null) firing a Kind 3187 would otherwise pass the heavyweight check
+        // and call resendCurrentKey — defeating the lightweight mute. The new
+        // AlreadyLightMuted variant + guard prevents the resend.
+        seedFollower("rider-A", approved = true, mutedAt = 100L)
+
+        val result = keyManager.handleFollowNotification(
+            signer = signer,
+            followerPubkey = "rider-A",
+            riderName = "rider-A-name"
+        )
+
+        assertEquals(FollowNotificationResult.AlreadyLightMuted, result)
+        coVerify(exactly = 0) {
+            nostrService.publishRoadflareKeyShare(any(), eq("rider-A"), any(), any())
+        }
+    }
+
+    @Test
+    fun `handleFollowNotification still resends key to approved follower without lightweight mute`() = runTest {
+        // Sanity: the new guard does not regress the existing approved-resend path.
+        seedFollower("rider-A", approved = true, mutedAt = null)
+
+        val result = keyManager.handleFollowNotification(
+            signer = signer,
+            followerPubkey = "rider-A",
+            riderName = "rider-A-name"
+        )
+
+        assertEquals(FollowNotificationResult.KeyResent, result)
+        coVerify(exactly = 1) {
+            nostrService.publishRoadflareKeyShare(any(), eq("rider-A"), any(), any())
+        }
+    }
+
+    @Test
+    fun `reconcileMuteStateFromBackup defers markMuteReconciled when followers empty but remote non-empty`() = runTest {
+        // Cross-PR seam fix: at-login reconciliation can fire BEFORE the Kind 30012 follower
+        // list sync completes. If we marked reconciled here, an auto-backup that fires next
+        // would trust the empty local mute list and publish-empty, overwriting remote
+        // `muted_pubkeys`. Defer the mark until we have followers to reconcile against.
+        assertFalse("baseline: flag is false", repository.isMuteReconciled())
+
+        keyManager.reconcileMuteStateFromBackup(
+            signer = signer,
+            remoteMutedPubkeys = listOf("rider-Z"),  // remote has a mute, but rider-Z isn't in our followers
+            remoteCreatedAt = 1_000L
+        )
+
+        assertFalse("flag must NOT flip when followers empty + remote non-empty", repository.isMuteReconciled())
+    }
+
+    @Test
+    fun `reconcileMuteStateFromBackup marks reconciled when followers empty AND remote empty`() = runTest {
+        // Both sides empty = nothing to do. We've observed remote and confirmed local matches.
+        // Safe to mark.
+        keyManager.reconcileMuteStateFromBackup(
+            signer = signer,
+            remoteMutedPubkeys = emptyList(),
+            remoteCreatedAt = 1_000L
+        )
+
+        assertTrue(repository.isMuteReconciled())
+    }
+
+    @Test
+    fun `reconcileMuteStateFromBackup marks reconciled when followers non-empty regardless of remote`() = runTest {
+        // Followers are populated → we can apply the algorithm correctly. Safe to mark.
+        seedFollower("rider-A")
+
+        keyManager.reconcileMuteStateFromBackup(
+            signer = signer,
+            remoteMutedPubkeys = listOf("rider-Z"),  // unknown to us, will be skipped
+            remoteCreatedAt = 1_000L
+        )
+
+        assertTrue(repository.isMuteReconciled())
     }
 
     // ── Code-review pass 1 fixes ──────────────────────────────────────────────

--- a/common/src/test/java/com/ridestr/common/roadflare/RoadflareMuteTest.kt
+++ b/common/src/test/java/com/ridestr/common/roadflare/RoadflareMuteTest.kt
@@ -1,0 +1,386 @@
+package com.ridestr.common.roadflare
+
+import androidx.test.core.app.ApplicationProvider
+import com.ridestr.common.data.DriverRoadflareRepository
+import com.ridestr.common.nostr.NostrService
+import com.ridestr.common.nostr.events.DriverRoadflareKey
+import com.ridestr.common.nostr.events.MutedRider
+import com.ridestr.common.nostr.events.RoadflareFollower
+import com.ridestr.common.nostr.events.RoadflareKey
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Regression tests for the lightweight per-follower mute feature (issue #80).
+ *
+ * Covers the seven acceptance criteria from the issue:
+ * 1. Mute / unmute basic flow.
+ * 2. Cross-device reconciliation: older-local mute + newer-backup → unmute locally.
+ * 3. Cross-device reconciliation: newer-local mute + older-backup → keep local mute.
+ * 4. Offline-mute persistence (mute → SharedPreferences round-trip → still muted).
+ * 5. Kind 30177 missing `muted_pubkeys` parses gracefully (delegated to
+ *    [com.ridestr.common.nostr.events.ProfileBackupEventMutedPubkeysParseTest], because
+ *    NIP-44 encryption is not exercisable from a unit test).
+ * 6. Kind 3186 send-loop skips muted pubkeys.
+ * 7. Unmute triggers Kind 3186 with the current key.
+ *
+ * Robolectric provides Android Context for [DriverRoadflareRepository]'s SharedPreferences;
+ * MockK fakes [NostrService] so we can verify (or refuse) Kind 3186 publishes deterministically.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class RoadflareMuteTest {
+
+    private lateinit var repository: DriverRoadflareRepository
+    private lateinit var nostrService: NostrService
+    private lateinit var keyManager: RoadflareKeyManager
+    private lateinit var signer: NostrSigner
+
+    private val driverKey = DriverRoadflareKey(
+        privateKey = "a".repeat(64),
+        publicKey = "b".repeat(64),
+        version = 7,
+        createdAt = 1_000L
+    )
+    private val keyUpdatedAt = 1_000L
+
+    @Before
+    fun setUp() {
+        // Fresh SharedPreferences-backed repository per test (Robolectric resets app state).
+        // The singleton accessor is bypassed via direct ctor so the field doesn't leak between tests.
+        repository = DriverRoadflareRepository(ApplicationProvider.getApplicationContext())
+        repository.clearAll()
+
+        nostrService = mockk(relaxed = true)
+        signer = mockk(relaxed = true)
+        every { signer.pubKey } returns "deadbeef".repeat(8)
+
+        // Default: any Kind 3186 publish "succeeds". Individual tests override as needed.
+        coEvery {
+            nostrService.publishRoadflareKeyShare(any(), any(), any(), any())
+        } returns "fake-event-id"
+
+        keyManager = RoadflareKeyManager(repository, nostrService)
+
+        // Establish a baseline driver key + keyUpdatedAt so the unmute path has something to send.
+        repository.setRoadflareKey(driverKey)
+        repository.updateKeyUpdatedAt(keyUpdatedAt)
+    }
+
+    @After
+    fun tearDown() {
+        repository.clearAll()
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private fun seedFollower(
+        pubkey: String,
+        approved: Boolean = true,
+        keyVersionSent: Int = driverKey.version,
+        mutedAt: Long? = null
+    ) {
+        repository.addFollower(
+            RoadflareFollower(
+                pubkey = pubkey,
+                name = "rider-$pubkey",
+                addedAt = 500L,
+                approved = approved,
+                keyVersionSent = keyVersionSent,
+                mutedAt = mutedAt
+            )
+        )
+    }
+
+    // ── Acceptance criterion 1: mute / unmute basic flow ─────────────────────
+
+    @Test
+    fun `muteFollower sets mutedAt and reports updated`() {
+        seedFollower("rider-A")
+
+        val updated = keyManager.muteFollower("rider-A", now = 9_999L)
+
+        assertTrue("expected updated=true for known follower", updated)
+        val follower = repository.getFollowers().single { it.pubkey == "rider-A" }
+        assertEquals(9_999L, follower.mutedAt)
+        assertTrue("isFollowerMuted should now report true", repository.isFollowerMuted("rider-A"))
+    }
+
+    @Test
+    fun `muteFollower no-ops on unknown pubkey`() {
+        val updated = keyManager.muteFollower("ghost-rider")
+        assertFalse("expected updated=false for unknown pubkey", updated)
+        assertTrue("repository should still be empty of followers", repository.getFollowers().isEmpty())
+    }
+
+    @Test
+    fun `unmuteFollower clears mutedAt and reports updated`() = runTest {
+        seedFollower("rider-A", mutedAt = 100L)
+
+        val updated = keyManager.unmuteFollower(signer, "rider-A")
+
+        assertTrue(updated)
+        val follower = repository.getFollowers().single { it.pubkey == "rider-A" }
+        assertNull("mutedAt should be cleared", follower.mutedAt)
+        assertFalse(repository.isFollowerMuted("rider-A"))
+    }
+
+    @Test
+    fun `unmuteFollower no-ops on unknown pubkey and does not publish key`() = runTest {
+        val updated = keyManager.unmuteFollower(signer, "ghost-rider")
+        assertFalse(updated)
+        coVerify(exactly = 0) {
+            nostrService.publishRoadflareKeyShare(any(), eq("ghost-rider"), any(), any())
+        }
+    }
+
+    // ── Acceptance criterion 2: cross-device — older local + newer backup ─────
+
+    @Test
+    fun `reconcile unmutes local follower when remote backup is newer and omits pubkey`() = runTest {
+        // Local: muted at T0 = 1_000, but remote backup created at T1 = 2_000 omits the pubkey
+        // → the remote unmute (any time at-or-after T0) wins.
+        seedFollower("rider-A", mutedAt = 1_000L)
+
+        val result = keyManager.reconcileMuteStateFromBackup(
+            signer = signer,
+            remoteMutedPubkeys = emptyList(),
+            remoteCreatedAt = 2_000L
+        )
+
+        assertEquals(0, result.muted)
+        assertEquals(1, result.unmuted)
+        assertEquals(1, result.keyResent)
+        assertNull(repository.getFollowers().single { it.pubkey == "rider-A" }.mutedAt)
+    }
+
+    // ── Acceptance criterion 3: cross-device — newer local + older backup ─────
+
+    @Test
+    fun `reconcile keeps local mute when local timestamp is newer than backup`() = runTest {
+        // Local: muted at T1 = 5_000, but remote backup is older (T0 = 2_000) and omits the pubkey
+        // → local mute is the more recent write → keep it; next publish syncs.
+        seedFollower("rider-A", mutedAt = 5_000L)
+
+        val result = keyManager.reconcileMuteStateFromBackup(
+            signer = signer,
+            remoteMutedPubkeys = emptyList(),
+            remoteCreatedAt = 2_000L
+        )
+
+        assertEquals(0, result.muted)
+        assertEquals(0, result.unmuted)
+        assertEquals(0, result.keyResent)
+        assertEquals(5_000L, repository.getFollowers().single { it.pubkey == "rider-A" }.mutedAt)
+        // No Kind 3186 sent — the local mute stays intact.
+        coVerify(exactly = 0) {
+            nostrService.publishRoadflareKeyShare(any(), eq("rider-A"), any(), any())
+        }
+    }
+
+    @Test
+    fun `reconcile mutes local follower when remote backup includes pubkey not yet muted locally`() = runTest {
+        // Inverse case: remote published a mute, local hasn't seen it.
+        seedFollower("rider-A", mutedAt = null)
+
+        val result = keyManager.reconcileMuteStateFromBackup(
+            signer = signer,
+            remoteMutedPubkeys = listOf("rider-A"),
+            remoteCreatedAt = 3_000L
+        )
+
+        assertEquals(1, result.muted)
+        assertEquals(0, result.unmuted)
+        assertEquals(3_000L, repository.getFollowers().single { it.pubkey == "rider-A" }.mutedAt)
+    }
+
+    @Test
+    fun `reconcile is idempotent on a second pass with same inputs`() = runTest {
+        seedFollower("rider-A", mutedAt = null)
+
+        val first = keyManager.reconcileMuteStateFromBackup(signer, listOf("rider-A"), remoteCreatedAt = 3_000L)
+        val second = keyManager.reconcileMuteStateFromBackup(signer, listOf("rider-A"), remoteCreatedAt = 3_000L)
+
+        assertEquals(1, first.muted)
+        assertEquals(0, second.muted)
+        assertFalse(second.changed)
+    }
+
+    @Test
+    fun `reconcile skips remote-muted pubkeys not present in local follower list`() = runTest {
+        // Remote backup mentions a pubkey we don't follow — nothing to mute, no error.
+        val result = keyManager.reconcileMuteStateFromBackup(
+            signer = signer,
+            remoteMutedPubkeys = listOf("ghost-rider"),
+            remoteCreatedAt = 1_500L
+        )
+
+        assertEquals(0, result.muted)
+        assertEquals(0, result.unmuted)
+        assertFalse(result.changed)
+    }
+
+    // ── Acceptance criterion 4: offline-mute persistence ──────────────────────
+
+    @Test
+    fun `mute persists across repository reload simulating app restart`() {
+        seedFollower("rider-A")
+
+        keyManager.muteFollower("rider-A", now = 4_242L)
+
+        // Simulate process death: build a new repository over the same SharedPreferences.
+        val reloaded = DriverRoadflareRepository(ApplicationProvider.getApplicationContext())
+        val follower = reloaded.getFollowers().single { it.pubkey == "rider-A" }
+        assertEquals(4_242L, follower.mutedAt)
+        assertTrue(reloaded.isFollowerMuted("rider-A"))
+    }
+
+    // ── Acceptance criterion 6: Kind 3186 send-loop skips muted pubkeys ───────
+
+    @Test
+    fun `getActiveFollowerPubkeys excludes lightweight-muted followers`() {
+        seedFollower("rider-A", mutedAt = null)
+        seedFollower("rider-B", mutedAt = 1_500L)
+        seedFollower("rider-C", mutedAt = null)
+
+        val active = repository.getActiveFollowerPubkeys()
+
+        assertEquals(setOf("rider-A", "rider-C"), active.toSet())
+    }
+
+    @Test
+    fun `getFollowersNeedingKey excludes lightweight-muted followers`() {
+        // All seeded with stale keyVersionSent so they would otherwise need a re-send.
+        seedFollower("rider-A", keyVersionSent = 0, mutedAt = null)
+        seedFollower("rider-B", keyVersionSent = 0, mutedAt = 1_500L)
+
+        val needing = repository.getFollowersNeedingKey().map { it.pubkey }.toSet()
+
+        assertEquals(setOf("rider-A"), needing)
+    }
+
+    @Test
+    fun `lightweight mute is independent of heavyweight MutedRider`() {
+        seedFollower("rider-A", mutedAt = 1L)
+        // Heavyweight mute would also flag "rider-A" via the legacy MutedRider list — the
+        // lightweight check must remain orthogonal so neither leaks into the other.
+        val current = repository.state.value!!
+        repository.restoreFromBackup(
+            current.copy(
+                muted = listOf(MutedRider(pubkey = "rider-Z", mutedAt = 1L))
+            )
+        )
+
+        assertTrue(repository.isFollowerMuted("rider-A"))
+        assertFalse(repository.isMuted("rider-A"))
+        assertFalse(repository.isFollowerMuted("rider-Z"))
+        assertTrue(repository.isMuted("rider-Z"))
+    }
+
+    // ── Acceptance criterion 7: unmute triggers Kind 3186 with current key ────
+
+    @Test
+    fun `unmuteFollower publishes Kind 3186 with current key and keyUpdatedAt`() = runTest {
+        seedFollower("rider-A", mutedAt = 100L)
+
+        keyManager.unmuteFollower(signer, "rider-A")
+
+        coVerify(exactly = 1) {
+            nostrService.publishRoadflareKeyShare(
+                signer = signer,
+                followerPubKey = "rider-A",
+                roadflareKey = match<RoadflareKey> {
+                    it.privateKey == driverKey.privateKey &&
+                        it.publicKey == driverKey.publicKey &&
+                        it.version == driverKey.version &&
+                        it.keyUpdatedAt == keyUpdatedAt
+                },
+                keyUpdatedAt = keyUpdatedAt
+            )
+        }
+        // Successful re-delivery should advance keyVersionSent on the follower row.
+        assertEquals(driverKey.version, repository.getFollowers().single { it.pubkey == "rider-A" }.keyVersionSent)
+    }
+
+    @Test
+    fun `unmuteFollower clears mutedAt even when Kind 3186 send fails`() = runTest {
+        // A transient relay failure must not block the local unmute — the next
+        // ensureFollowersHaveCurrentKey run can recover delivery.
+        coEvery {
+            nostrService.publishRoadflareKeyShare(any(), eq("rider-A"), any(), any())
+        } returns null
+        seedFollower("rider-A", mutedAt = 100L)
+
+        val updated = keyManager.unmuteFollower(signer, "rider-A")
+
+        assertTrue("local unmute is the source of truth — must report updated even on send failure", updated)
+        assertNull(repository.getFollowers().single { it.pubkey == "rider-A" }.mutedAt)
+    }
+
+    @Test
+    fun `reconcile unmute also re-delivers Kind 3186 with current key`() = runTest {
+        // The cross-device unmute path (reconciliation case 3) must re-deliver the key the
+        // same way as the explicit unmute UX action — otherwise the rider would be silently
+        // unable to decrypt new broadcasts after a remote unmute.
+        seedFollower("rider-A", mutedAt = 1_000L)
+
+        keyManager.reconcileMuteStateFromBackup(
+            signer = signer,
+            remoteMutedPubkeys = emptyList(),
+            remoteCreatedAt = 2_000L
+        )
+
+        coVerify(exactly = 1) {
+            nostrService.publishRoadflareKeyShare(
+                signer = signer,
+                followerPubKey = "rider-A",
+                roadflareKey = match<RoadflareKey> { it.version == driverKey.version },
+                keyUpdatedAt = keyUpdatedAt
+            )
+        }
+    }
+
+    // ── Repository-level invariants for the new mute helpers ──────────────────
+
+    @Test
+    fun `getMutedFollowerPubkeys returns only lightweight-muted entries`() {
+        seedFollower("rider-A", mutedAt = 1L)
+        seedFollower("rider-B", mutedAt = null)
+        seedFollower("rider-C", mutedAt = 99L)
+
+        assertEquals(setOf("rider-A", "rider-C"), repository.getMutedFollowerPubkeys().toSet())
+    }
+
+    @Test
+    fun `setFollowerMuted on already-muted follower overwrites mutedAt`() {
+        seedFollower("rider-A", mutedAt = 100L)
+
+        val updated = repository.setFollowerMuted("rider-A", 999L)
+
+        assertTrue(updated)
+        assertEquals(999L, repository.getFollowers().single { it.pubkey == "rider-A" }.mutedAt)
+    }
+
+    @Test
+    fun `setFollowerUnmuted on already-unmuted follower still reports updated`() {
+        // Idempotent semantic: as long as the row exists, the call is "successful".
+        // Callers can still trigger republish; reconciliation doesn't rely on the boolean.
+        seedFollower("rider-A", mutedAt = null)
+        assertTrue(repository.setFollowerUnmuted("rider-A"))
+    }
+}

--- a/common/src/test/java/com/ridestr/common/roadflare/RoadflareMuteTest.kt
+++ b/common/src/test/java/com/ridestr/common/roadflare/RoadflareMuteTest.kt
@@ -383,4 +383,74 @@ class RoadflareMuteTest {
         seedFollower("rider-A", mutedAt = null)
         assertTrue(repository.setFollowerUnmuted("rider-A"))
     }
+
+    // ── Code-review pass 1 fixes ──────────────────────────────────────────────
+
+    @Test
+    fun `unmuteFollower persists keyUpdatedAt fallback when repo value is null`() = runTest {
+        // PR #79 fixed exactly this hazard for `resendCurrentKey`: when getKeyUpdatedAt() is null,
+        // the local fallback to key.createdAt MUST be persisted via updateKeyUpdatedAt — otherwise
+        // the next publishDriverRoadflareState falls through to DriverRoadflareStateEvent.create's
+        // wall-clock fallback (line 77) and silently advances the public key_updated_at tag,
+        // invalidating riders' stored keys.
+        //
+        // Reset the keyUpdatedAt that setUp seeded so we can exercise the null-fallback branch.
+        val current = repository.state.value!!
+        repository.restoreFromBackup(current.copy(keyUpdatedAt = null))
+        seedFollower("rider-A", mutedAt = 100L)
+
+        val updated = keyManager.unmuteFollower(signer, "rider-A")
+
+        assertTrue(updated)
+        assertEquals(
+            "expected unmuteFollower to persist key.createdAt as keyUpdatedAt",
+            driverKey.createdAt,
+            repository.getKeyUpdatedAt()
+        )
+    }
+
+    @Test
+    fun `reconcile unmute persists keyUpdatedAt fallback when repo value is null`() = runTest {
+        // Same hazard, second affected path: the Case B unmute branch of
+        // reconcileMuteStateFromBackup also sends Kind 3186 with the fallback keyUpdatedAt.
+        val current = repository.state.value!!
+        repository.restoreFromBackup(current.copy(keyUpdatedAt = null))
+        seedFollower("rider-A", mutedAt = 1_000L)
+
+        keyManager.reconcileMuteStateFromBackup(
+            signer = signer,
+            remoteMutedPubkeys = emptyList(),
+            remoteCreatedAt = 2_000L
+        )
+
+        assertEquals(driverKey.createdAt, repository.getKeyUpdatedAt())
+    }
+
+    @Test
+    fun `reconcile unmute does NOT re-deliver key when rider is heavyweight-muted`() = runTest {
+        // Cross-device hazard: device 1 lightweight-mutes a rider; device 2 then "Removes" them
+        // (handleMuteFollower → muteRider + rotateKey). If device 2's Kind 30177 is older than
+        // device 1's lightweight mute, device 1's reconciliation would otherwise unmute the
+        // rider AND re-deliver the post-rotation key — defeating device 2's heavyweight mute.
+        // The reconciliation must clear the lightweight mute (so state stays consistent) but
+        // skip Kind 3186 delivery.
+        seedFollower("rider-A", mutedAt = 1_000L)
+        // Heavyweight-mute the same rider via the legacy path (simulates a "Remove" from another device).
+        repository.muteRider("rider-A", reason = "removed on device 2")
+
+        val result = keyManager.reconcileMuteStateFromBackup(
+            signer = signer,
+            remoteMutedPubkeys = emptyList(),
+            remoteCreatedAt = 2_000L
+        )
+
+        assertEquals(0, result.muted)
+        assertEquals("local lightweight mute is cleared so it converges with remote", 1, result.unmuted)
+        assertEquals("Kind 3186 must NOT be re-delivered to a heavyweight-muted rider", 0, result.keyResent)
+        coVerify(exactly = 0) {
+            nostrService.publishRoadflareKeyShare(any(), eq("rider-A"), any(), any())
+        }
+        // Heavyweight mute is unaffected.
+        assertTrue("heavyweight mute must still be in effect", repository.isMuted("rider-A"))
+    }
 }

--- a/common/src/test/java/com/ridestr/common/sync/ProfileSyncAdapterTest.kt
+++ b/common/src/test/java/com/ridestr/common/sync/ProfileSyncAdapterTest.kt
@@ -1,6 +1,7 @@
 package com.ridestr.common.sync
 
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.ridestr.common.data.DriverRoadflareRepository
 import com.ridestr.common.data.SavedLocation
 import com.ridestr.common.data.SavedLocationRepository
 import com.ridestr.common.data.Vehicle
@@ -381,5 +382,135 @@ class ProfileSyncAdapterTest {
 
         assertTrue("Should publish on FetchFailed when both repos present", result != null)
         coVerify(exactly = 1) { nostrService.publishProfileBackup(any(), any(), any()) }
+    }
+
+    // ── Issue #80 mute reconciliation gate (pass-3 fix) ──────────────────────
+
+    @Test
+    fun `publishToNostr preserves remote muted_pubkeys when reconciliation has NOT run`() = testScope.runTest {
+        // Pass-3 hazard: on a fresh device first key-import, the local follower list and
+        // therefore the lightweight-mute set are empty until BOTH Kind 30012 sync AND Kind
+        // 30177 reconciliation finish. An auto-backup (settings hash, vehicle change) that
+        // fires before those complete must NOT publish an empty muted_pubkeys list — that
+        // would silently overwrite the remote authoritative mute state. The
+        // `isMuteReconciled()` gate distinguishes "haven't observed remote yet" from
+        // "deliberately empty".
+        settingsRepository.awaitInitialLoad()
+
+        val driverRoadflareRepository = mockk<DriverRoadflareRepository>(relaxed = true)
+        every { driverRoadflareRepository.isMuteReconciled() } returns false
+        every { driverRoadflareRepository.getMutedFollowerPubkeys() } returns emptyList()
+
+        val remoteMuted = listOf("a".repeat(64), "b".repeat(64))
+        val existingProfile = ProfileBackupData(
+            eventId = "existing-with-mutes",
+            vehicles = emptyList(),
+            savedLocations = emptyList(),
+            settings = SettingsBackup(),
+            mutedFollowerPubkeys = remoteMuted,
+            updatedAt = System.currentTimeMillis(),
+            createdAt = System.currentTimeMillis()
+        )
+
+        val mutedSlot = slot<List<String>>()
+        coEvery { nostrService.fetchProfileBackupResult() } returns ProfileFetchResult.Found(existingProfile)
+        every { vehicleRepository.vehicles } returns MutableStateFlow(emptyList())
+        coEvery {
+            nostrService.publishProfileBackup(any(), any(), any(), capture(mutedSlot))
+        } returns "event-pass3-preserve"
+
+        val adapter = ProfileSyncAdapter(
+            vehicleRepository = vehicleRepository,
+            savedLocationRepository = null,
+            settingsRepository = settingsRepository,
+            nostrService = nostrService,
+            driverRoadflareRepository = driverRoadflareRepository
+        )
+
+        adapter.publishToNostr(mockSigner, mockRelayManager)
+
+        assertEquals("remote muted_pubkeys must be preserved before reconciliation runs", remoteMuted, mutedSlot.captured)
+    }
+
+    @Test
+    fun `publishToNostr trusts local muted_pubkeys after reconciliation has run`() = testScope.runTest {
+        // Inverse of the previous test: once reconciliation has confirmed local matches
+        // remote, an empty local list means the user deliberately unmuted everyone. The
+        // publish must respect that and emit an empty muted_pubkeys list (which the create
+        // path then omits from the wire payload entirely).
+        settingsRepository.awaitInitialLoad()
+
+        val driverRoadflareRepository = mockk<DriverRoadflareRepository>(relaxed = true)
+        every { driverRoadflareRepository.isMuteReconciled() } returns true
+        every { driverRoadflareRepository.getMutedFollowerPubkeys() } returns emptyList()
+
+        val existingProfile = ProfileBackupData(
+            eventId = "existing-with-mutes",
+            vehicles = emptyList(),
+            savedLocations = emptyList(),
+            settings = SettingsBackup(),
+            mutedFollowerPubkeys = listOf("a".repeat(64)),
+            updatedAt = System.currentTimeMillis(),
+            createdAt = System.currentTimeMillis()
+        )
+
+        val mutedSlot = slot<List<String>>()
+        coEvery { nostrService.fetchProfileBackupResult() } returns ProfileFetchResult.Found(existingProfile)
+        every { vehicleRepository.vehicles } returns MutableStateFlow(emptyList())
+        coEvery {
+            nostrService.publishProfileBackup(any(), any(), any(), capture(mutedSlot))
+        } returns "event-pass3-trust-local"
+
+        val adapter = ProfileSyncAdapter(
+            vehicleRepository = vehicleRepository,
+            savedLocationRepository = null,
+            settingsRepository = settingsRepository,
+            nostrService = nostrService,
+            driverRoadflareRepository = driverRoadflareRepository
+        )
+
+        adapter.publishToNostr(mockSigner, mockRelayManager)
+
+        assertTrue("local empty muted_pubkeys must be respected after reconciliation", mutedSlot.captured.isEmpty())
+    }
+
+    @Test
+    fun `publishToNostr emits local muted_pubkeys when reconciled and non-empty`() = testScope.runTest {
+        settingsRepository.awaitInitialLoad()
+
+        val driverRoadflareRepository = mockk<DriverRoadflareRepository>(relaxed = true)
+        every { driverRoadflareRepository.isMuteReconciled() } returns true
+        val localMuted = listOf("c".repeat(64), "d".repeat(64))
+        every { driverRoadflareRepository.getMutedFollowerPubkeys() } returns localMuted
+
+        // Even if remote has different content, local wins after reconciliation.
+        val existingProfile = ProfileBackupData(
+            eventId = "existing-with-different-mutes",
+            vehicles = emptyList(),
+            savedLocations = emptyList(),
+            settings = SettingsBackup(),
+            mutedFollowerPubkeys = listOf("e".repeat(64)),
+            updatedAt = System.currentTimeMillis(),
+            createdAt = System.currentTimeMillis()
+        )
+
+        val mutedSlot = slot<List<String>>()
+        coEvery { nostrService.fetchProfileBackupResult() } returns ProfileFetchResult.Found(existingProfile)
+        every { vehicleRepository.vehicles } returns MutableStateFlow(emptyList())
+        coEvery {
+            nostrService.publishProfileBackup(any(), any(), any(), capture(mutedSlot))
+        } returns "event-pass3-local-wins"
+
+        val adapter = ProfileSyncAdapter(
+            vehicleRepository = vehicleRepository,
+            savedLocationRepository = null,
+            settingsRepository = settingsRepository,
+            nostrService = nostrService,
+            driverRoadflareRepository = driverRoadflareRepository
+        )
+
+        adapter.publishToNostr(mockSigner, mockRelayManager)
+
+        assertEquals(localMuted, mutedSlot.captured)
     }
 }

--- a/drivestr/src/main/java/com/drivestr/app/MainActivity.kt
+++ b/drivestr/src/main/java/com/drivestr/app/MainActivity.kt
@@ -242,7 +242,8 @@ fun DrivestrApp(settingsRepository: SettingsRepository) {
                 vehicleRepository = vehicleRepository,
                 savedLocationRepository = null,  // Driver app doesn't use saved locations
                 settingsRepository = settingsRepository,
-                nostrService = nostrService
+                nostrService = nostrService,
+                driverRoadflareRepository = driverRoadflareRepo  // Issue #80: include muted_pubkeys in Kind 30177
             ))
             psm.registerSyncable(RideHistorySyncAdapter(rideHistoryRepository, nostrService))
             psm.registerSyncable(DriverRoadflareSyncAdapter(driverRoadflareRepo, nostrService))
@@ -345,6 +346,24 @@ fun DrivestrApp(settingsRepository: SettingsRepository) {
         nostrService.relayManager.awaitConnected(tag = "roadflareDriverSubs")
 
         val asyncScope = this
+
+        // Issue #80: app-start mute reconciliation. Fetch own Kind 30177 once and apply
+        // last-write-wins reconciliation against local follower mute state. Best-effort —
+        // a fetch failure leaves local state untouched. If anything changed, republish so
+        // other devices converge. Fire-and-forget on a child coroutine so the subscription
+        // setup below isn't blocked by the network round-trip.
+        asyncScope.launch {
+            try {
+                val signer = nostrService.keyManager.getSigner() ?: return@launch
+                val result = roadflareKeyManager.fetchAndReconcileMuteFromBackup(signer)
+                if (result?.changed == true) {
+                    android.util.Log.d("MainActivity", "Mute reconciliation: muted=${result.muted}, unmuted=${result.unmuted}, keyResent=${result.keyResent} — republishing profile backup")
+                    profileSyncManager.backupProfileData()
+                }
+            } catch (e: Exception) {
+                android.util.Log.w("MainActivity", "Mute reconciliation failed at startup", e)
+            }
+        }
 
         val subId = nostrService.subscribeToRoadflareFollowNotifications { event, relayUrl ->
             // Check if we should ignore notifications (dev setting for testing p-tag queries)
@@ -452,10 +471,14 @@ fun DrivestrApp(settingsRepository: SettingsRepository) {
                         if (!pubkeyMatches) {
                             android.util.Log.w("MainActivity", "Key ack pubkey mismatch - ignoring (claimed=${ackData.riderPubKey.take(8)}, signer=${event.pubKey.take(8)})")
                         } else {
-                            // Verify authorized follower (approved + not muted)
+                            // Verify authorized follower (approved + not muted via either path).
+                            // - Heavyweight mute (`MutedRider` / "Remove" UX) excludes the rider entirely.
+                            // - Lightweight mute (issue #80, `RoadflareFollower.mutedAt`) suppresses
+                            //   key delivery — re-sends in response to acks would defeat the mute.
                             val follower = driverRoadflareRepo.getFollowers().find { it.pubkey == ackData.riderPubKey }
                             val isMuted = driverRoadflareRepo.getMutedPubkeys().contains(ackData.riderPubKey)
-                            val isAuthorized = follower != null && follower.approved && !isMuted
+                            val isLightMuted = follower?.mutedAt != null
+                            val isAuthorized = follower != null && follower.approved && !isMuted && !isLightMuted
 
                             if (!isAuthorized) {
                                 android.util.Log.w("MainActivity", "Key ack from unauthorized follower - ignoring")
@@ -1383,6 +1406,22 @@ fun MainScreen(
                                     followerPubkey = pubkey,
                                     reason = "removed by driver"
                                 )
+                                profileSyncManager.backupProfileData()
+                            }
+                        }
+                    },
+                    onMuteFollower = { pubkey ->
+                        // Lightweight mute (issue #80) — no key rotation. Local-authoritative;
+                        // synced cross-device via Kind 30177's `muted_pubkeys` (last-write-wins).
+                        if (roadflareKeyManager.muteFollower(pubkey)) {
+                            scope.launch { profileSyncManager.backupProfileData() }
+                        }
+                    },
+                    onUnmuteFollower = { pubkey ->
+                        // Lightweight unmute (issue #80) — re-delivers current key via Kind 3186.
+                        scope.launch {
+                            val signer = nostrService.keyManager.getSigner() ?: return@launch
+                            if (roadflareKeyManager.unmuteFollower(signer, pubkey)) {
                                 profileSyncManager.backupProfileData()
                             }
                         }

--- a/drivestr/src/main/java/com/drivestr/app/MainActivity.kt
+++ b/drivestr/src/main/java/com/drivestr/app/MainActivity.kt
@@ -351,7 +351,8 @@ fun DrivestrApp(settingsRepository: SettingsRepository) {
         // last-write-wins reconciliation against local follower mute state. Best-effort —
         // a fetch failure leaves local state untouched. If anything changed, republish so
         // other devices converge. Fire-and-forget on a child coroutine so the subscription
-        // setup below isn't blocked by the network round-trip.
+        // setup below isn't blocked by the network round-trip. CancellationException is
+        // explicitly re-thrown so logout / nav-away cancellation propagates correctly.
         asyncScope.launch {
             try {
                 val signer = nostrService.keyManager.getSigner() ?: return@launch
@@ -360,6 +361,8 @@ fun DrivestrApp(settingsRepository: SettingsRepository) {
                     android.util.Log.d("MainActivity", "Mute reconciliation: muted=${result.muted}, unmuted=${result.unmuted}, keyResent=${result.keyResent} — republishing profile backup")
                     profileSyncManager.backupProfileData()
                 }
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
             } catch (e: Exception) {
                 android.util.Log.w("MainActivity", "Mute reconciliation failed at startup", e)
             }
@@ -1266,17 +1269,25 @@ fun MainScreen(
             // sync on a fresh device first key-import) are applied. Reconciliation is
             // idempotent — re-running it with the same backup is a no-op for already-applied
             // mutes.
-            try {
-                val signer = nostrService.keyManager.getSigner()
-                if (signer != null) {
-                    val result = roadflareKeyManager.fetchAndReconcileMuteFromBackup(signer)
-                    if (result?.changed == true) {
-                        android.util.Log.d("MainActivity", "Post-sync mute reconciliation: muted=${result.muted}, unmuted=${result.unmuted}, keyResent=${result.keyResent} — republishing profile backup")
-                        profileSyncManager.backupProfileData()
+            //
+            // Wrapped in a child launch + explicit CancellationException re-throw so that a
+            // logout / nav-away cancellation does NOT silently allow `backupProfileData()` to
+            // execute on a cancelled scope. Mirrors the at-login pattern above.
+            launch {
+                try {
+                    val signer = nostrService.keyManager.getSigner()
+                    if (signer != null) {
+                        val result = roadflareKeyManager.fetchAndReconcileMuteFromBackup(signer)
+                        if (result?.changed == true) {
+                            android.util.Log.d("MainActivity", "Post-sync mute reconciliation: muted=${result.muted}, unmuted=${result.unmuted}, keyResent=${result.keyResent} — republishing profile backup")
+                            profileSyncManager.backupProfileData()
+                        }
                     }
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    android.util.Log.w("MainActivity", "Post-sync mute reconciliation failed", e)
                 }
-            } catch (e: Exception) {
-                android.util.Log.w("MainActivity", "Post-sync mute reconciliation failed", e)
             }
         }
     }

--- a/drivestr/src/main/java/com/drivestr/app/MainActivity.kt
+++ b/drivestr/src/main/java/com/drivestr/app/MainActivity.kt
@@ -1259,6 +1259,25 @@ fun MainScreen(
         if (isConnected && !hasInitialSynced) {
             hasInitialSynced = true
             refreshRoadflareStateAndFollowers()
+
+            // Issue #80 — chained mute reconciliation: now that Kind 30012 has populated the
+            // followers list, run the lightweight-mute reconciliation a second time so any
+            // remote-muted pubkeys missed by the at-login pass (which races against this very
+            // sync on a fresh device first key-import) are applied. Reconciliation is
+            // idempotent — re-running it with the same backup is a no-op for already-applied
+            // mutes.
+            try {
+                val signer = nostrService.keyManager.getSigner()
+                if (signer != null) {
+                    val result = roadflareKeyManager.fetchAndReconcileMuteFromBackup(signer)
+                    if (result?.changed == true) {
+                        android.util.Log.d("MainActivity", "Post-sync mute reconciliation: muted=${result.muted}, unmuted=${result.unmuted}, keyResent=${result.keyResent} — republishing profile backup")
+                        profileSyncManager.backupProfileData()
+                    }
+                }
+            } catch (e: Exception) {
+                android.util.Log.w("MainActivity", "Post-sync mute reconciliation failed", e)
+            }
         }
     }
 

--- a/drivestr/src/main/java/com/drivestr/app/MainActivity.kt
+++ b/drivestr/src/main/java/com/drivestr/app/MainActivity.kt
@@ -428,6 +428,9 @@ fun DrivestrApp(settingsRepository: SettingsRepository) {
                                     is FollowNotificationResult.AlreadyMuted -> {
                                         android.util.Log.d("MainActivity", "Follow notification from muted ${notification.riderPubKey.take(16)} — preserving driver's Remove decision")
                                     }
+                                    is FollowNotificationResult.AlreadyLightMuted -> {
+                                        android.util.Log.d("MainActivity", "Follow notification from lightweight-muted ${notification.riderPubKey.take(16)} — preserving driver's Mute decision")
+                                    }
                                     is FollowNotificationResult.AlreadyPending -> {
                                         android.util.Log.d("MainActivity", "Follow notification from pending ${notification.riderPubKey.take(16)} — awaiting driver approval")
                                     }

--- a/drivestr/src/main/java/com/drivestr/app/ui/screens/RoadflareTab.kt
+++ b/drivestr/src/main/java/com/drivestr/app/ui/screens/RoadflareTab.kt
@@ -53,6 +53,8 @@ fun RoadflareTab(
     onApproveFollower: (String) -> Unit = {},
     onDeclineFollower: (String) -> Unit = {},
     onRemoveFollower: (String) -> Unit = {},
+    onMuteFollower: (String) -> Unit = {},
+    onUnmuteFollower: (String) -> Unit = {},
     onRefreshFollowers: (suspend () -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
@@ -337,7 +339,9 @@ fun RoadflareTab(
                 items(approvedFollowers, key = { it.pubkey }) { follower ->
                     FollowerCard(
                         follower = follower,
-                        onRemove = { showRemoveDialog = follower }
+                        onRemove = { showRemoveDialog = follower },
+                        onMute = { onMuteFollower(follower.pubkey) },
+                        onUnmute = { onUnmuteFollower(follower.pubkey) }
                     )
                 }
             }
@@ -674,19 +678,38 @@ private fun PendingFollowerCard(
 
 /**
  * Card for an approved follower.
+ *
+ * Supports two distinct destructive/restrictive actions:
+ * - **Mute** ([onMute] / [onUnmute]): lightweight per-follower suppression (issue #80). No
+ *   key rotation; reversible by Unmute. Visual: greyed-out card + "Muted" badge while muted.
+ * - **Remove** ([onRemove]): heavyweight removal that rotates the RoadFlare key. Recoverable
+ *   only via Settings > Removed Followers.
+ *
+ * The menu item that's shown for the lightweight mute swaps between "Mute" and "Unmute"
+ * based on [RoadflareFollower.mutedAt].
  */
 @Composable
 private fun FollowerCard(
     follower: RoadflareFollower,
     onRemove: () -> Unit,
+    onMute: () -> Unit,
+    onUnmute: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var showMenu by remember { mutableStateOf(false) }
     val dateFormat = remember { SimpleDateFormat("MMM d, yyyy", Locale.getDefault()) }
     val displayName = follower.name.ifEmpty { "${follower.pubkey.take(8)}...${follower.pubkey.takeLast(4)}" }
+    val isMuted = follower.mutedAt != null
 
     Card(
-        modifier = modifier.fillMaxWidth()
+        modifier = modifier.fillMaxWidth(),
+        colors = if (isMuted) {
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+            )
+        } else {
+            CardDefaults.cardColors()
+        }
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -694,17 +717,25 @@ private fun FollowerCard(
                 .fillMaxWidth()
                 .padding(16.dp)
         ) {
-            // Avatar placeholder
+            // Avatar placeholder (greyed when muted)
             Surface(
                 shape = MaterialTheme.shapes.medium,
-                color = MaterialTheme.colorScheme.secondaryContainer,
+                color = if (isMuted) {
+                    MaterialTheme.colorScheme.surfaceVariant
+                } else {
+                    MaterialTheme.colorScheme.secondaryContainer
+                },
                 modifier = Modifier.size(40.dp)
             ) {
                 Box(contentAlignment = Alignment.Center) {
                     Icon(
-                        imageVector = Icons.Default.Person,
+                        imageVector = if (isMuted) Icons.Default.NotificationsOff else Icons.Default.Person,
                         contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSecondaryContainer
+                        tint = if (isMuted) {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        } else {
+                            MaterialTheme.colorScheme.onSecondaryContainer
+                        }
                     )
                 }
             }
@@ -712,12 +743,34 @@ private fun FollowerCard(
             Spacer(modifier = Modifier.width(12.dp))
 
             Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = displayName,
-                    style = MaterialTheme.typography.bodyMedium,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = displayName,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (isMuted) {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        } else {
+                            MaterialTheme.colorScheme.onSurface
+                        },
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f, fill = false)
+                    )
+                    if (isMuted) {
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Surface(
+                            shape = MaterialTheme.shapes.small,
+                            color = MaterialTheme.colorScheme.surfaceVariant
+                        ) {
+                            Text(
+                                text = "Muted",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+                            )
+                        }
+                    }
+                }
 
                 Text(
                     text = "Added ${dateFormat.format(Date(follower.addedAt * 1000))}",
@@ -739,6 +792,35 @@ private fun FollowerCard(
                     expanded = showMenu,
                     onDismissRequest = { showMenu = false }
                 ) {
+                    if (isMuted) {
+                        DropdownMenuItem(
+                            text = { Text("Unmute") },
+                            onClick = {
+                                showMenu = false
+                                onUnmute()
+                            },
+                            leadingIcon = {
+                                Icon(
+                                    Icons.Default.Notifications,
+                                    contentDescription = null
+                                )
+                            }
+                        )
+                    } else {
+                        DropdownMenuItem(
+                            text = { Text("Mute") },
+                            onClick = {
+                                showMenu = false
+                                onMute()
+                            },
+                            leadingIcon = {
+                                Icon(
+                                    Icons.Default.NotificationsOff,
+                                    contentDescription = null
+                                )
+                            }
+                        )
+                    }
                     DropdownMenuItem(
                         text = { Text("Remove", color = MaterialTheme.colorScheme.error) },
                         onClick = {


### PR DESCRIPTION
Closes #80.

## Summary

Adds a driver-side per-follower **lightweight mute** that suppresses Kind 3186 key
delivery for one rider without rotating the RoadFlare key. Distinct from the
existing heavyweight `MutedRider` / "Remove" path, which still rotates the key
and removes the rider entirely. The new mute is reversible by Unmute and synced
cross-device via Kind 30177's new `muted_pubkeys` field with last-write-wins on
`created_at`.

## Design (locked from issue #80)

- **Local source of truth** is `RoadflareFollower.mutedAt: Long?` on each
  follower row (null = not muted). Persisted in the existing
  `DriverRoadflareRepository` SharedPreferences. Active-follower and
  needs-key queries skip lightweight-muted rows.
- **Cross-device sync** rides Kind 30177's encrypted payload as a top-level
  `muted_pubkeys: [hex32...]` array — no new event type, no new subscription.
  Field is omitted from the wire payload when empty so rider apps and pre-#80
  drivers produce identical bytes (zero migration cost).
- **Reconciliation** uses last-write-wins on the Kind 30177 `created_at`:
    - In remote, not local → mute locally with `mutedAt = remoteCreatedAt`.
    - Muted locally with `mutedAt > remoteCreatedAt`, not in remote → keep
      local; next publish syncs out.
    - Muted locally with `mutedAt <= remoteCreatedAt`, not in remote → unmute
      and best-effort re-deliver Kind 3186.
- **Send-loop integration**: `getActiveFollowerPubkeys` and
  `getFollowersNeedingKey` exclude lightweight-muted rows. The Kind 3188
  key-ack handler also treats `mutedAt != null` as unauthorized so a stale
  ack does not trigger a re-send and defeat the mute.

## Coexistence with PR #79

This branch is cut from current `main` (without #79's changes). Designed to
rebase mechanically onto post-#79 main:

- Touches `MainActivity.kt`'s Kind 3187/3188 LaunchedEffect block (line ~340
  area) and `RoadflareKeyManager.kt`. PR #79 also touches both, but modifies
  *different* methods (`handleNewFollower` → `handleFollowNotification` vs.
  the new `muteFollower` / `unmuteFollower` / `reconcileMuteStateFromBackup`).
  Conflicts at merge-time will be straightforward.
- The lightweight mute does NOT replace `RoadflareDriverCoordinator.mergeMutedLists`'
  "once muted, always muted" invariant (which is about Kind 30012's heavyweight
  `MutedRider`). Both mute concepts coexist; the new one uses Kind 30177 last-
  write-wins, the existing one keeps Kind 30012 union semantics.
- The `MainActivity.kt` Kind 3188 ack handler had a `getMutedPubkeys()` check
  that's untouched here; the new `mutedAt` check is added alongside it.

## Acceptance criteria (from issue #80)

- [x] New mute UX action in the followers list (driver UI) — `RoadflareTab` /
      `FollowerCard` swap menu item.
- [x] New unmute UX action visible only on currently-muted entries.
- [x] `Followers` DataStore carries `MUTED` state — `RoadflareFollower.mutedAt`.
- [x] Kind 30177 backup payload includes `muted_pubkeys` field.
- [x] App-start reconciliation merges remote backup into local state with
      last-write-wins — fire-and-forget child coroutine in MainActivity's
      logged-in `LaunchedEffect`.
- [x] Kind 3186 send-loop skips muted pubkeys.
- [x] Unmute triggers a Kind 3186 with the current RoadFlare key.
- [x] Regression tests: mute / unmute / reconcile (older-local + newer-backup;
      newer-local + older-backup); offline-mute persistence; Kind 30177 with
      missing `muted_pubkeys` parses gracefully.

## Code change

| File | What |
| ---- | ---- |
| `common/.../events/DriverRoadflareStateEvent.kt` | `RoadflareFollower.mutedAt: Long?` field + JSON round-trip |
| `common/.../data/DriverRoadflareRepository.kt` | `setFollowerMuted` / `setFollowerUnmuted` / `getMutedFollowerPubkeys` / `isFollowerMuted` helpers + send-loop exclusion |
| `common/.../events/ProfileBackupEvent.kt` | `muted_pubkeys` field on `create()` (omit when empty) + `parseAndDecrypt()` reads it back into `ProfileBackupData.mutedFollowerPubkeys` |
| `common/.../nostr/ProfileBackupService.kt` + `NostrService.kt` | Forward optional `mutedFollowerPubkeys` parameter (default empty for non-driver paths) |
| `common/.../sync/ProfileSyncAdapter.kt` | Optional `driverRoadflareRepository` ctor parameter; publish reads `getMutedFollowerPubkeys()` |
| `common/.../roadflare/RoadflareKeyManager.kt` | `muteFollower` / `unmuteFollower` / `reconcileMuteStateFromBackup` / `fetchAndReconcileMuteFromBackup` + `MuteReconciliationResult` |
| `drivestr/.../ui/screens/RoadflareTab.kt` | `onMuteFollower` / `onUnmuteFollower` callbacks; `FollowerCard` swap-menu item + greyed/badge for muted entries |
| `drivestr/.../app/MainActivity.kt` | Wire UI callbacks; pass `driverRoadflareRepo` to `ProfileSyncAdapter`; app-start mute reconciliation hook; Kind 3188 ack handler skips lightweight-muted |
| `common/src/test/.../RoadflareMuteTest.kt` | Robolectric + MockK suite — 18 cases pinning AC1–AC4, AC6, AC7 |
| `common/src/test/.../ProfileBackupEventMutedPubkeysTest.kt` | Schema tests for AC5 (4 cases) |

## Test plan

- [x] `:common:assembleDebug` clean
- [x] `:drivestr:assembleDebug` clean
- [x] `:rider-app:assembleDebug` + `:roadflare-rider:assembleDebug` clean (verifies the new optional `ProfileSyncAdapter` ctor parameter is non-breaking)
- [x] `:common:testDebugUnitTest` + `:drivestr:testDebugUnitTest` — full suites pass (4 new test files / 22 new cases included)
- [ ] Manual: drivestr + 2 rider clients. Mute rider A from drivestr; verify A stops receiving Kind 3186 + B keeps getting location broadcasts. Unmute A; verify Kind 3186 is re-delivered with the current key version (no rotation, no version bump).
- [ ] Manual: cross-device — drivestr on device 1 mutes rider A; sign in on device 2; verify A appears as muted in the followers list after the app-start reconciliation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)